### PR TITLE
Add CDTQProjectedDocumentRevision subclass

### DIFF
--- a/Pod/Classes/CDTQLogging.h
+++ b/Pod/Classes/CDTQLogging.h
@@ -1,10 +1,16 @@
 //
 //  CDTQueryLogging.h
-//  Pods
 //
 //  Created by Rhys Short on 07/10/2014.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
 //
-//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
 
 #ifndef Pods_CDTQueryLogging_h
 #define Pods_CDTQueryLogging_h

--- a/Pod/Classes/CDTQProjectedDocumentRevision.h
+++ b/Pod/Classes/CDTQProjectedDocumentRevision.h
@@ -1,0 +1,39 @@
+//
+//  CDTQProjectedDocumentRevision.h
+//
+//  Created by Michael Rhodes on 18/10/2014.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTDocumentRevision.h"
+
+@class CDTDatastore;
+
+/**
+ A document revision that has been projected.
+ 
+ This class implements a version of mutableCopy which returns the full
+ document when called, to prevent accidental data loss which might come
+ from saving a projected document.
+ */
+@interface CDTQProjectedDocumentRevision : CDTDocumentRevision
+
+/**
+ Initialise with a datastore so mutableCopy can return a full document.
+ */
+- (id)initWithDocId:(NSString *)docId
+        revisionId:(NSString *)revId
+              body:(NSDictionary *)body
+           deleted:(BOOL)deleted
+       attachments:(NSDictionary *)attachments
+          sequence:(SequenceNumber)sequence
+         datastore:(CDTDatastore*)datastore;
+
+@end

--- a/Pod/Classes/CDTQProjectedDocumentRevision.m
+++ b/Pod/Classes/CDTQProjectedDocumentRevision.m
@@ -1,0 +1,63 @@
+//
+//  CDTQProjectedDocumentRevision.m
+//
+//  Created by Michael Rhodes on 18/10/2014.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTQProjectedDocumentRevision.h"
+
+#import <CloudantSync.h>
+
+@interface CDTQProjectedDocumentRevision ()
+
+@property (nonatomic,strong) CDTDatastore *datastore;
+
+@end
+
+@implementation CDTQProjectedDocumentRevision
+
+- (id)initWithDocId:(NSString *)docId
+         revisionId:(NSString *)revId
+               body:(NSDictionary *)body
+            deleted:(BOOL)deleted
+        attachments:(NSDictionary *)attachments
+           sequence:(SequenceNumber)sequence
+          datastore:(CDTDatastore*)datastore
+{
+    self = [self initWithDocId:docId
+                    revisionId:revId
+                          body:body
+                       deleted:deleted
+                   attachments:attachments 
+                      sequence:sequence];
+    if (self != nil) {
+        _datastore = datastore;
+    }
+    return self;
+}
+
+- (CDTMutableDocumentRevision*)mutableCopy
+{
+    CDTDocumentRevision *rev = [self.datastore getDocumentWithId:self.docId
+                                                           error:nil];
+    if (rev == nil) {
+        return nil;
+    }
+    
+    // Don't want to return an updated version, breaks contract of mutableCopy
+    if (![rev.revId isEqualToString:self.revId]) {
+        return nil;
+    }
+    
+    return [rev mutableCopy];
+}
+
+@end

--- a/Pod/Classes/CDTQResultSet.m
+++ b/Pod/Classes/CDTQResultSet.m
@@ -14,6 +14,8 @@
 
 #import "CDTQResultSet.h"
 #import "CDTQLogging.h"
+#import "CDTQProjectedDocumentRevision.h"
+
 #import <CloudantSync.h>
 
 @interface CDTQResultSet ()
@@ -58,7 +60,7 @@
     __unsafe_unretained NSArray *docs = [_datastore getDocumentsWithIds:batchIds];
     
     if(self.fields){
-        docs = [CDTQResultSet projectFields:self.fields fromRevisions:docs];
+        docs = [CDTQResultSet projectFields:self.fields fromRevisions:docs datastore:_datastore];
     }
     
     int i;
@@ -72,21 +74,25 @@
     return i;
 }
 
-+ (NSArray *)projectFields:(NSArray *) fields fromRevisions:(NSArray *)revisions
++ (NSArray *)projectFields:(NSArray*)fields 
+             fromRevisions:(NSArray*)revisions
+                 datastore:(CDTDatastore*)datastore
 {
 
     NSMutableArray * projectedDocs = [NSMutableArray array];
     
     for(CDTDocumentRevision * rev in revisions){
-            //grab the dictionary filter fields and rebuild object
-            NSDictionary * body = [rev.body dictionaryWithValuesForKeys:fields];
-            CDTDocumentRevision *rev2 = [[CDTDocumentRevision alloc] initWithDocId:rev.docId
-                                                  revisionId:rev.revId
-                                                        body:body
-                                                     deleted:rev.deleted
-                                                 attachments:rev.attachments
-                                                    sequence:rev.sequence];
-            [projectedDocs addObject:rev2];
+        //grab the dictionary filter fields and rebuild object
+        NSDictionary * body = [rev.body dictionaryWithValuesForKeys:fields];
+        CDTQProjectedDocumentRevision *rev2 = [[CDTQProjectedDocumentRevision alloc]
+                                               initWithDocId:rev.docId
+                                               revisionId:rev.revId
+                                               body:body
+                                               deleted:rev.deleted
+                                               attachments:rev.attachments
+                                               sequence:rev.sequence
+                                               datastore:datastore];
+        [projectedDocs addObject:rev2];
     }
     return projectedDocs;
 


### PR DESCRIPTION
This subclass of CDTDocumentRevision overrides -mutableCopy to return
the non-projected version of the document's body to avoid data loss
by accidentally overwriting a document with its projection.

Addresses #20 

@rhyshort, @tomblench  please take a look at this
