### PR TITLE
Move limting and skiping of results into class method

### DIFF
--- a/Example/Tests/CDTQQueryExecutorTests.m
+++ b/Example/Tests/CDTQQueryExecutorTests.m
@@ -171,37 +171,7 @@ describe(@"cloudant query", ^{
                 
                 expect([results.documentIds count]).to.equal(0);
             });
-            
-            it(@"returns an array with results when limit is over array bounds", ^{
-                NSDictionary *query = @{@"name": @{@"$eq": @"mike"}};
-                CDTQResultSet * results = [im find:query skip:0 limit:4 fields:nil sort:nil];
-                
-                expect([results.documentIds count]).to.equal(3);
-            });
-            
-            it(@"returns all results with very large limit", ^{
-                NSDictionary *query = @{@"name": @{@"$eq": @"mike"}};
-                CDTQResultSet * results = [im find:query skip:0 limit:1000 fields:nil sort:nil];
-                
-                expect([results.documentIds count]).to.equal(3);
-            });
-            
-            it(@"returns an array with no results when range is out of bounds",^{
-                NSDictionary *query = @{@"name": @{@"$eq": @"mike"}};
-                CDTQResultSet * results = [im find:query skip:4 limit:4 fields:nil sort:nil];
-                
-                expect([results.documentIds count]).to.equal(0);
-                
-            });
-            
-            it(@"returns appropriate results skip and large limit used",^{
-                NSDictionary *query = @{@"name": @{@"$eq": @"mike"}};
-                CDTQResultSet * results = [im find:query skip:2 limit:1000 fields:nil sort:nil];
-                
-                expect([results.documentIds count]).to.equal(1);
-                
-            });
-            
+
         });
         
         describe(@"when using unsupported operator", ^{
@@ -956,5 +926,39 @@ describe(@"cloudant query", ^{
     });
     
 });
+
+    describe(@"when skipping and limiting results", ^{
+    
+        it(@"returns an array with results when limit is over array bounds", ^{
+            NSArray * docIds = @[@"doc1", @"doc2", @"doc3"];
+            NSArray *trimmed = [CDTQQueryExecutor applySkip:0 andLimit:4 toResultSet:docIds];
+            NSArray * expected = [docIds subarrayWithRange:NSMakeRange(0, 3)];
+            expect(trimmed).to.equal(expected);
+        });
+    
+        it(@"returns all results with very large limit", ^{
+            NSArray * docIds = @[@"doc1", @"doc2", @"doc3"];
+            NSArray *trimmed = [CDTQQueryExecutor applySkip:0 andLimit:1000 toResultSet:docIds];
+            NSArray * expected = [docIds subarrayWithRange:NSMakeRange(0, 3)];
+            expect(trimmed).to.equal(expected);
+        });
+    
+        it(@"returns an array with no results when range is out of bounds",^{
+            NSArray * docIds = @[@"doc1", @"doc2", @"doc3"];
+            NSArray *trimmed = [CDTQQueryExecutor applySkip:4 andLimit:4 toResultSet:docIds];
+            NSArray * expected = [docIds subarrayWithRange:NSMakeRange(0, 0)];
+            expect(trimmed).to.equal(expected);
+        
+        });
+    
+        it(@"returns appropriate results skip and large limit used",^{
+            NSArray * docIds = @[@"doc1", @"doc2", @"doc3"];
+            NSArray *trimmed = [CDTQQueryExecutor applySkip:4 andLimit:4 toResultSet:docIds];
+            NSArray * expected = [docIds subarrayWithRange:NSMakeRange(0, 0)];
+            expect(trimmed).to.equal(expected);
+        });
+    
+    });
+
 
 SpecEnd

--- a/Pod/Classes/CDTQQueryExecutor.h
+++ b/Pod/Classes/CDTQQueryExecutor.h
@@ -61,5 +61,6 @@
                    usingOrder:(NSArray/*NSDictionary*/*)sortDocument
                       indexes:(NSDictionary*)indexes;
 
++ (NSArray *) applySkip:(NSUInteger)skip andLimit:(NSUInteger)limit toResultSet:(NSArray*)docIds;
 
 @end

--- a/Pod/Classes/CDTQQueryExecutor.m
+++ b/Pod/Classes/CDTQQueryExecutor.m
@@ -99,18 +99,23 @@ const NSUInteger kSmallResultSetSizeThreshold = 500;
         return nil;
     }
     
-    // skip + limit
-    if(skip < docIds.count){
-        NSUInteger maxLength = docIds.count - skip;
-        NSRange range = NSMakeRange(skip, MIN(limit, maxLength));
-        docIds = [docIds subarrayWithRange:range];
-    } else {
-        docIds =  @[];
-    }
+    docIds = [CDTQQueryExecutor applySkip:skip andLimit:limit toResultSet:docIds];
     
     return [[CDTQResultSet alloc] initWithDocIds:docIds
                                        datastore:self.datastore
-                                projectionFields:fields];  
+                                projectionFields:fields];
+}
++ (NSArray *) applySkip:(NSUInteger)skip andLimit:(NSUInteger)limit toResultSet:(NSArray*)docIds
+{
+    NSArray *limitedResults = nil;
+    if(skip < docIds.count){
+        NSUInteger maxLength = docIds.count - skip;
+        NSRange range = NSMakeRange(skip, MIN(limit, maxLength));
+        limitedResults = [docIds subarrayWithRange:range];
+    } else {
+        limitedResults =  @[];
+    }
+    return limitedResults;
 }
 
 #pragma mark Validation helpers


### PR DESCRIPTION
To speed up testing, the skiping and limiting of results
has been moved into a class method. Enabling testing of
the limiting and skipping code without excuting a full
query
