### PR TITLE
Added Clang Format File

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,17 @@
+BasedOnStyle: Google
+ColumnLimit: 100
+IndentWidth: 4
+UseTab: Never
+BreakBeforeBraces: Linux
+BreakBeforeBinaryOperators: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PointerBindsToType: false
+SpacesBeforeTrailingComments: 2
+SpaceBeforeParens: ControlStatements
+TabWidth: 4
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowShortBlocksOnASingleLine: false
+MaxEmptyLinesToKeep: 1
+ObjCSpaceAfterProperty: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+Contributing
+---
+
+## Code Style
+
+Code style for CloudantQueryObjc is defined with a clang format file (.clang-format) in the root of the project. All code should be formatted using the clang-format tool. 
+
+####Installing clang-format into Xcode
+
+Clang-format should be installed into xcode using the [ClangFormat-Xcode](https://github.com/travisjeffery/ClangFormat-Xcode) plug-in, the easiest way to do this is via [Alcatraz](https://github.com/mneorr/Alcatraz). You can also install the plugin from source using the instractions at [ClangFormat-Xcode](https://github.com/travisjeffery/ClangFormat-Xcode).
+
+#####Setting up Xcode
+
+We suggest Xcode should be set up to use clang-format to format code on save, and map the format command to `ctrl-i`
+
+- Setting clang-format to run on save 
+
+
+    In the menu, open Edit > Clang Format > Click Format on save (a checkmark appears in this menu item indicicating that the feature is active.)
+
+- Assign keyboard shortcut
+
+    - Open the System Preferences > Keyboard > Shortcuts > App Shortcuts > Click `+`
+    - Set the application to be Xcode
+    - Set the menu title to "Format File in Focus"
+    - Set your shortcut to `ctrl-i`et your shortcut to `ctrl-i`


### PR DESCRIPTION
Added .clang-format to specify the code format for the project.
It relies on the tool clang-format. clang-format is not shipped
in xcode command line tools. To use clang-format inside xcode
download and install clangformat-xcode
https://github.com/travisjeffery/ClangFormat-Xcode

This is as close as I could get from the options as I understand them, it matches closely to the style we specify only major difference i've noticed is a line break after assignment operator  if the statement takes it over the 100 column hard limit.
