### PR TITLE
Upgrade logging to be compatible with CocoaLumberjack 2.0.0-beta4

### DIFF
--- a/CloudantQueryObjc.podspec
+++ b/CloudantQueryObjc.podspec
@@ -34,5 +34,5 @@ Pod::Spec.new do |s|
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
   s.dependency 'CDTDatastore', '>= 0.7'
-  s.dependency 'CocoaLumberjack'
+  s.dependency 'CocoaLumberjack', '= 2.0.0-beta4'
 end

--- a/Pod/Classes/CDTQLogging.h
+++ b/Pod/Classes/CDTQLogging.h
@@ -15,20 +15,27 @@
 #ifndef Pods_CDTQueryLogging_h
 #define Pods_CDTQueryLogging_h
 
-#import "DDLog.h"
+#import "CocoaLumberjack.h"
 
 #define CDTQ_LOGGING_CONTEXT 17  // one level higher than CDT logger myabe should be 20?
-static int CDTQLogLevel = LOG_LEVEL_WARN;
+static DDLogLevel CDTQLogLevel = DDLogLevelWarning;
 
-#define LogError(frmt, ...) \
-    SYNC_LOG_OBJC_MAYBE(CDTQLogLevel, LOG_FLAG_ERROR, CDTQ_LOGGING_CONTEXT, frmt, ##__VA_ARGS__)
-#define LogWarn(frmt, ...) \
-    ASYNC_LOG_OBJC_MAYBE(CDTQLogLevel, LOG_FLAG_WARN, CDTQ_LOGGING_CONTEXT, frmt, ##__VA_ARGS__)
-#define LogInfo(frmt, ...) \
-    ASYNC_LOG_OBJC_MAYBE(CDTQLogLevel, LOG_FLAG_INFO, CDTQ_LOGGING_CONTEXT, frmt, ##__VA_ARGS__)
-#define LogDebug(frmt, ...) \
-    ASYNC_LOG_OBJC_MAYBE(CDTQLogLevel, LOG_FLAG_DEBUG, CDTQ_LOGGING_CONTEXT, frmt, ##__VA_ARGS__)
-#define LogVerbose(frmt, ...) \
-    ASYNC_LOG_OBJC_MAYBE(CDTQLogLevel, LOG_FLAG_VERBOSE, CDTQ_LOGGING_CONTEXT, frmt, ##__VA_ARGS__)
+#define LogError(frmt, ...)                                                                      \
+    LOG_MAYBE(NO, CDTQLogLevel, DDLogLevelError, CDTQ_LOGGING_CONTEXT, nil, __PRETTY_FUNCTION__, \
+              frmt, ##__VA_ARGS__)
+#define LogWarn(frmt, ...)                                                     \
+    LOG_MAYBE(YES, CDTQLogLevel, DDLogLevelWarning, CDTQ_LOGGING_CONTEXT, nil, \
+              __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define LogInfo(frmt, ...)                                                                       \
+    LOG_MAYBE(YES, CDTQLogLevel, DDLogLevelInfo, CDTQ_LOGGING_CONTEXT, nil, __PRETTY_FUNCTION__, \
+              frmt, ##__VA_ARGS__)
+#define LogDebug(frmt, ...)                                                                       \
+    LOG_MAYBE(YES, CDTQLogLevel, DDLogLevelDebug, CDTQ_LOGGING_CONTEXT, nil, __PRETTY_FUNCTION__, \
+              frmt, ##__VA_ARGS__)
+#define LogVerbose(frmt, ...)                                                  \
+    LOG_MAYBE(YES, CDTQLogLevel, DDLogLevelVerbose, CDTQ_LOGGING_CONTEXT, nil, \
+              __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+
 #define CDTQChangeLogLevel(level) CDTQLogLevel = level
+
 #endif


### PR DESCRIPTION
Upgrade logging marcos to work with CocoaLumberjack 2.0.0-beta4. Beta 4
is incompitable with beta3 as a result the podspec is updated to rely on
beta 4. It is pinned to beta4 to avoid unexpected breaking changes.
