### PR TITLE
Change limit behaviour so 0 disables limiting

### DIFF
--- a/Example/Tests/CDTQQueryExecutorTests.m
+++ b/Example/Tests/CDTQQueryExecutorTests.m
@@ -166,6 +166,12 @@ SharedExamplesBegin(QueryExecution)
 
             context(@"when limiting and offsetting results", ^{
 
+                it(@"returns all for skip = limit = 0", ^{
+                    NSDictionary* query = @{ @"name" : @{@"$eq" : @"mike"} };
+                    CDTQResultSet* results = [im find:query skip:0 limit:0 fields:nil sort:nil];
+                    expect(results.documentIds.count).to.equal(3);
+                });
+
                 it(@"limits query results", ^{
                     NSDictionary* query = @{ @"name" : @{@"$eq" : @"mike"} };
                     CDTQResultSet* results = [im find:query skip:0 limit:1 fields:nil sort:nil];
@@ -182,14 +188,12 @@ SharedExamplesBegin(QueryExecution)
                     expect(results.documentIds[1]).to.equal(offsetResults.documentIds[0]);
                 });
 
-                it(@"returns empty array when skip results goes over array bounds", ^{
+                it(@"disables limit for 0", ^{
                     NSDictionary* query = @{ @"name" : @{@"$eq" : @"mike"} };
-                    CDTQResultSet* results = [im find:query skip:2 limit:0 fields:nil sort:nil];
+                    CDTQResultSet* results = [im find:query skip:1 limit:0 fields:nil sort:nil];
 
-                    expect([results.documentIds count]).to.equal(0);
+                    expect([results.documentIds count]).to.equal(2);
                 });
-
-                // ===
 
                 it(@"returns an array with results when limit is over array bounds", ^{
                     NSDictionary* query = @{ @"name" : @{@"$eq" : @"mike"} };

--- a/Pod/Classes/CDTQIndexManager.m
+++ b/Pod/Classes/CDTQIndexManager.m
@@ -310,7 +310,7 @@ static const int VERSION = 1;
 
 - (CDTQResultSet *)find:(NSDictionary *)query
 {
-    return [self find:query skip:0 limit:NSUIntegerMax fields:nil sort:nil];
+    return [self find:query skip:0 limit:0 fields:nil sort:nil];
 }
 
 - (CDTQResultSet *)find:(NSDictionary *)query
@@ -323,7 +323,7 @@ static const int VERSION = 1;
         LogError(@"-find called with nil selector; bailing.");
         return nil;
     }
-    
+
     if (![self updateAllIndexes]) {
         return nil;
     }

--- a/Pod/Classes/CDTQResultSet.m
+++ b/Pod/Classes/CDTQResultSet.m
@@ -85,10 +85,6 @@
     CDTQUnindexedMatcher *matcher = self.matcher;
     NSArray *fields = self.fields;
 
-    if (limit == 0) {
-        return;
-    }
-
     BOOL stop = NO;
     NSUInteger batchSize = 50;
     NSRange range = NSMakeRange(0, batchSize);

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ NSArray *sortDocument = @[ @{ @"name": @"asc" },
                            @{ @"age": @"desc" } ];
 CDTQResultSet *result = [im find:query
                             skip:0
-                           limit:NSUIntegerMax
+                           limit:0
                           fields:nil
                             sort:sortDocument];
 ```
@@ -270,7 +270,7 @@ To project the `name` and `age` fields of the above document:
 NSArray *fields = @[ @"name", @"age" ];
 CDTQResultSet *result = [im find:query
                             skip:0
-                           limit:NSUIntegerMax
+                           limit:0
                           fields:fields
                             sort:nil];
 ```
@@ -298,7 +298,7 @@ CDTQResultSet *result = [im find:query
 To disable:
 
 - `skip`, pass `0` as the `skip` argument.
-- `limit`, pass `NSUIntegerMax` as the `limit` argument.
+- `limit`, pass `0` as the `limit` argument.
 
 ### Array fields
 
@@ -363,9 +363,9 @@ However, if there was one index with `pet` in and another with `name` in, like t
 
 ```objc
 NSString *name = [im ensureIndexed:@[@"name", @"age"] 
-                          withName:@"basic"];
+                          withName:@"one_index"];
 NSString *name = [im ensureIndexed:@[@"age", @"pet"] 
-                          withName:@"basic"]
+                          withName:@"another_index"]
 ```
 
 The document _would_ be indexed in both of these indexes: each index only contains one of
@@ -438,8 +438,6 @@ Overall restrictions:
 
 #### Query syntax
 
-- Sorting results #7.
-- Field projection #8.
 - Using non-dotted notation to query sub-documents.
     - That is, `{"pet": { "species": {"$eq": "cat"} } }` is unsupported,
       you must use `{"pet.species": {"$eq": "cat"}}`.


### PR DESCRIPTION
Previously, limit=0 would return no results. This seemed against
common patterns for this kind of thing in other systems.

Fixes #37
