### PR TITLE
Fix post-hoc matching when projecting fields

### DIFF
--- a/Example/Tests/CDTQQueryExecutorTests.m
+++ b/Example/Tests/CDTQQueryExecutorTests.m
@@ -1267,6 +1267,14 @@ sharedExamplesFor(@"queries without covering indexes", ^(NSDictionary* data) {
             expect(result.documentIds.count).to.equal(2);
             expect(result.documentIds).to.beSupersetOf(@[ @"mike72", @"fred12" ]);
         });
+
+        it(@"post-hoc matches when projecting over non-queried fields", ^{
+            NSDictionary* query = @{ @"town" : @"bristol" };
+            CDTQResultSet* result = [im find:query skip:0 limit:0 fields:@[ @"name" ] sort:nil];
+            expect(result).toNot.beNil();
+            expect(result.documentIds.count).to.equal(2);
+            expect(result.documentIds).to.beSupersetOf(@[ @"mike72", @"fred12" ]);
+        });
     });
 });
 


### PR DESCRIPTION
Before this, the projection would happen before the post-hoc matching
stage. The problem there was that the matcher would end up operating
on the projected revision. If the projection removed a field the
post-hoc matcher was checking, the revision would be rejected.

As a side effect, this removes the overhead of projecting every
document, regardless of skip, limit and matching.

Fixes #39.
