### PR TITLE
Separated Validation and normalisation into single step

### DIFF
--- a/Example/Tests/CDTQInvalidQuerySyntax.m
+++ b/Example/Tests/CDTQInvalidQuerySyntax.m
@@ -13,131 +13,146 @@
 #import <CDTQResultSet.h>
 #import <CDTQQueryExecutor.h>
 
-SpecBegin(CDTQQueryExecutorInvalidSyntax)
+SpecBegin(CDTQQueryExecutorInvalidSyntax) describe(@"cloudant query using invalid syntax", ^{
 
-    // TODO re-enable when validation moved to separate step
-    xdescribe(@"cloudant query using invalid syntax", ^{
+    __block NSString *factoryPath;
+    __block CDTDatastoreManager *factory;
 
-        __block NSString *factoryPath;
-        __block CDTDatastoreManager *factory;
+    beforeEach(^{
+        // Create a new CDTDatastoreFactory at a temp path
+
+        NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
+            stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+        const char *tempDirectoryTemplateCString = [tempDirectoryTemplate fileSystemRepresentation];
+        char *tempDirectoryNameCString = (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+        strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+
+        char *result = mkdtemp(tempDirectoryNameCString);
+        expect(result).to.beTruthy();
+
+        factoryPath = [[NSFileManager defaultManager]
+            stringWithFileSystemRepresentation:tempDirectoryNameCString
+                                        length:strlen(result)];
+        free(tempDirectoryNameCString);
+
+        NSError *error;
+        factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+    });
+
+    afterEach(^{
+        // Delete the databases we used
+
+        factory = nil;
+        NSError *error;
+        [[NSFileManager defaultManager] removeItemAtPath:factoryPath error:&error];
+    });
+
+    describe(@"When using query ", ^{
+
+        __block CDTDatastore *ds;
+        __block CDTQIndexManager *im;
 
         beforeEach(^{
-            // Create a new CDTDatastoreFactory at a temp path
+            ds = [factory datastoreNamed:@"test" error:nil];
+            expect(ds).toNot.beNil();
 
-            NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
-                stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
-            const char *tempDirectoryTemplateCString =
-                [tempDirectoryTemplate fileSystemRepresentation];
-            char *tempDirectoryNameCString =
-                (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
-            strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+            CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
 
-            char *result = mkdtemp(tempDirectoryNameCString);
-            expect(result).to.beTruthy();
+            rev.docId = @"mike12";
+            rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+            [ds createDocumentFromRevision:rev error:nil];
 
-            factoryPath = [[NSFileManager defaultManager]
-                stringWithFileSystemRepresentation:tempDirectoryNameCString
-                                            length:strlen(result)];
-            free(tempDirectoryNameCString);
+            rev.docId = @"mike34";
+            rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+            [ds createDocumentFromRevision:rev error:nil];
 
-            NSError *error;
-            factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+            rev.docId = @"mike72";
+            rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.docId = @"fred34";
+            rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.docId = @"fred12";
+            rev.body = @{ @"name" : @"fred", @"age" : @12 };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+            expect(im).toNot.beNil();
+
+            expect([im ensureIndexed:@[ @"name", @"age" ] withName:@"basic"]).toNot.beNil();
+            expect([im ensureIndexed:@[ @"name", @"pet" ] withName:@"pet"]).toNot.beNil();
         });
 
-        afterEach(^{
-            // Delete the databases we used
-
-            factory = nil;
-            NSError *error;
-            [[NSFileManager defaultManager] removeItemAtPath:factoryPath error:&error];
+        it(@"returns nil when arugment to $or is a string", ^{
+            NSDictionary *query = @{ @"$or" : @"I should be an array" };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
         });
 
-        describe(@"When using query ", ^{
-
-            __block CDTDatastore *ds;
-            __block CDTQIndexManager *im;
-
-            beforeEach(^{
-                ds = [factory datastoreNamed:@"test" error:nil];
-                expect(ds).toNot.beNil();
-
-                im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
-                expect(im).toNot.beNil();
-
-                [im ensureIndexed:@[ @"name" ] withName:@"basic"];
-
-            });
-
-            it(@"returns nil when arugment to $or is a string", ^{
-                NSDictionary *query = @{ @"$or" : @"I should be an array" };
-                CDTQResultSet *result = [im find:query];
-                expect(result).to.beNil();
-            });
-
-            it(@"returns nil when array passed to $or contains only a string", ^{
-                NSDictionary *query = @{ @"$or" : @[ @"I should be an array" ] };
-                CDTQResultSet *result = [im find:query];
-                expect(result).to.beNil();
-            });
-
-            it(@"returns nil when array passed to $or contains only one empty dict", ^{
-                NSDictionary *query = @{ @"$or" : @[ @{} ] };
-                CDTQResultSet *result = [im find:query];
-                expect(result).to.beNil();
-            });
-
-            it(@"returns nil when $or syntax is incorrect, using one correct dict and one empty "
-               @"dict",
-               ^{
-                NSDictionary *query = @{ @"$or" : @[ @{@"name" : @"mike"}, @{} ] };
-                CDTQResultSet *result = [im find:query];
-                expect(result).to.beNil();
-            });
-
-            it(@"returns nil when comparing attempting to use unsupported array comparison", ^{
-                NSDictionary *query = @{ @"friends" : @[] };
-                CDTQResultSet *result = [im find:query];
-                expect(result).to.beNil();
-            });
-
-            it(@"returns nil when $eq is top level element", ^{
-                NSDictionary *query = @{ @"$eq" : @"$eq should not be top level thing" };
-                CDTQResultSet *result = [im find:query];
-                expect(result).to.beNil();
-            });
-
-            it(@"returns nil when array passed to $eq contains only a string", ^{
-                NSDictionary *query = @{ @"name" : @[ @"I should be a dict" ] };
-                CDTQResultSet *result = [im find:query];
-                expect(result).to.beNil();
-            });
-
-            it(@"returns nil when compareing field value to empty dict", ^{
-                NSDictionary *query = @{ @"name" : @{} };
-                CDTQResultSet *result = [im find:query];
-                expect(result).to.beNil();
-            });
-
-            it(@"returns nil when using $or syntax for $eq", ^{
-                NSDictionary *query = @{ @"name" : @[ @{@"$eq" : @"mike"} ] };
-                CDTQResultSet *result = [im find:query];
-                expect(result).to.beNil();
-            });
-
-            it(@"returns nil when $eq syntax is incorrect, using an array of dictionaries", ^{
-                NSDictionary *query = @{ @"name" : @[ @{@"$eq" : @"mike"}, @{} ] };
-                CDTQResultSet *result = [im find:query];
-                expect(result).to.beNil();
-            });
-
-            it(@"returns nil when $exists has argument other than boolean", ^{
-                NSDictionary *query = @{ @"name" : @{@"$exists" : @{}} };
-                CDTQResultSet *result = [im find:query];
-                expect(result).to.beNil();
-            });
-
+        it(@"returns nil when array passed to $or contains only a string", ^{
+            NSDictionary *query = @{ @"$or" : @[ @"I should be an array" ] };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
         });
 
+        it(@"returns nil when array passed to $or contains only one empty dict", ^{
+            NSDictionary *query = @{ @"$or" : @[ @{} ] };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
+        });
+
+        it(@"returns nil when $or syntax is incorrect, using one correct dict and one empty "
+           @"dict",
+           ^{
+            NSDictionary *query = @{ @"$or" : @[ @{@"name" : @"mike"}, @{} ] };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
+        });
+
+        it(@"returns nil when comparing attempting to use unsupported array comparison", ^{
+            NSDictionary *query = @{ @"friends" : @[] };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
+        });
+
+        it(@"returns nil when $eq is top level element", ^{
+            NSDictionary *query = @{ @"$eq" : @"$eq should not be top level thing" };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
+        });
+
+        it(@"returns nil when array passed to $eq contains only a string", ^{
+            NSDictionary *query = @{ @"name" : @[ @"I should be a dict" ] };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
+        });
+
+        it(@"returns nil when compareing field value to empty dict", ^{
+            NSDictionary *query = @{ @"name" : @{} };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
+        });
+
+        it(@"returns nil when using $or syntax for $eq", ^{
+            NSDictionary *query = @{ @"name" : @[ @{@"$eq" : @"mike"} ] };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
+        });
+
+        it(@"returns nil when $eq syntax is incorrect, using an array of dictionaries", ^{
+            NSDictionary *query = @{ @"name" : @[ @{@"$eq" : @"mike"}, @{} ] };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
+        });
+
+        it(@"returns nil when $exists has argument other than boolean", ^{
+            NSDictionary *query = @{ @"name" : @{@"$exists" : @{}} };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
+        });
     });
+});
 
 SpecEnd

--- a/Example/Tests/CDTQQueryExecutorTests.m
+++ b/Example/Tests/CDTQQueryExecutorTests.m
@@ -224,7 +224,6 @@ SharedExamplesBegin(QueryExecution)
 
                     expect([results.documentIds count]).to.equal(0);
                 });
-
             });
 
             // TODO fill in when separate validation class written
@@ -335,7 +334,6 @@ SharedExamplesBegin(QueryExecution)
                         expect(rev.body[@"age"]).to.equal(12);
                     }];
                 });
-
             });
 
             describe(@"when using $lte operator", ^{
@@ -443,7 +441,6 @@ SharedExamplesBegin(QueryExecution)
                 CDTQResultSet* result = [im find:query];
                 expect(result.documentIds).to.equal(@[ @"mike23" ]);
             });
-
         });
 
         describe(@"when using non-ascii text", ^{
@@ -835,7 +832,6 @@ SharedExamplesBegin(QueryExecution)
                 expect(result).toNot.beNil();
                 expect(result.documentIds.count).to.equal(1);
             });
-
         });
 
         describe(@"_rev is queryable", ^{
@@ -878,7 +874,6 @@ SharedExamplesBegin(QueryExecution)
                 expect(result).toNot.beNil();
                 expect(result.documentIds.count).to.equal(1);
             });
-
         });
 
         describe(@"when using $not", ^{
@@ -975,7 +970,6 @@ SharedExamplesBegin(QueryExecution)
                 expect(result).toNot.beNil();
                 expect(result.documentIds.count).to.equal(5);
             });
-
         });
 
         describe(@"when indexing array fields", ^{
@@ -1027,7 +1021,6 @@ SharedExamplesBegin(QueryExecution)
                 expect(result.documentIds.count).to.equal(2);
                 expect(result.documentIds).to.equal(@[ @"mike12", @"fred34" ]);
             });
-
         });
 
         describe(@"when using the $exists operator", ^{
@@ -1095,7 +1088,6 @@ SharedExamplesBegin(QueryExecution)
                 expect(result).toNot.beNil();
                 expect([result.documentIds count]).to.equal(1);
             });
-
         });
 
         describe(@"stopping enumeration", ^{
@@ -1362,12 +1354,10 @@ sharedExamplesFor(@"queries without covering indexes", ^(NSDictionary* data) {
 SharedExamplesEnd
 
     // This spec pushes the standard CDTQQueryExecutor through the shared behaviour tests.
-    SpecBegin(CDTQQueryExecutor)
-
-        describe(@"full with covering", ^{
-            NSDictionary* data = @{ @"index_manager_class" : [CDTQIndexManager class] };
-            itShouldBehaveLike(@"queries with covering indexes", data);
-        });
+    SpecBegin(CDTQQueryExecutor) describe(@"full with covering", ^{
+        NSDictionary* data = @{ @"index_manager_class" : [CDTQIndexManager class] };
+        itShouldBehaveLike(@"queries with covering indexes", data);
+    });
 
 describe(@"full without covering", ^{
     NSDictionary* data = @{ @"index_manager_class" : [CDTQIndexManager class] };
@@ -1377,12 +1367,10 @@ describe(@"full without covering", ^{
 SpecEnd
 
     // This class skips the matcher to check that SQL only returns the same
-    SpecBegin(CDTQSQLOnlyQueryExecutor)
-
-        describe(@"sql with covering", ^{
-            NSDictionary* data = @{ @"index_manager_class" : [CDTQSQLOnlyIndexManager class] };
-            itShouldBehaveLike(@"queries with covering indexes", data);
-        });
+    SpecBegin(CDTQSQLOnlyQueryExecutor) describe(@"sql with covering", ^{
+        NSDictionary* data = @{ @"index_manager_class" : [CDTQSQLOnlyIndexManager class] };
+        itShouldBehaveLike(@"queries with covering indexes", data);
+    });
 
 // Don't run "queries without covering indexes" as they'll obviously not work
 
@@ -1390,12 +1378,10 @@ SpecEnd
 
     // This class skips SQL and just uses the matcher to ensure the matcher class returns
     // the same as the SQL version.
-    SpecBegin(CDTQMatcherQueryExecutor)
-
-        describe(@"matcher with covering", ^{
-            NSDictionary* data = @{ @"index_manager_class" : [CDTQMatcherIndexManager class] };
-            itShouldBehaveLike(@"queries with covering indexes", data);
-        });
+    SpecBegin(CDTQMatcherQueryExecutor) describe(@"matcher with covering", ^{
+        NSDictionary* data = @{ @"index_manager_class" : [CDTQMatcherIndexManager class] };
+        itShouldBehaveLike(@"queries with covering indexes", data);
+    });
 
 describe(@"matcher without covering", ^{
     NSDictionary* data = @{ @"index_manager_class" : [CDTQMatcherIndexManager class] };

--- a/Example/Tests/CDTQQuerySqlTranslatorTests.m
+++ b/Example/Tests/CDTQQuerySqlTranslatorTests.m
@@ -13,873 +13,886 @@
 #import <CDTQResultSet.h>
 #import <CDTQQueryExecutor.h>
 #import <CDTQQuerySqlTranslator.h>
+#import <CDTQQueryValidator.h>
 #import <Specta.h>
 #import <Expecta.h>
 
-SpecBegin(CDTQQuerySqlTranslator)
+SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
 
-    describe(@"cdtq", ^{
+    __block NSString *factoryPath;
+    __block CDTDatastoreManager *factory;
 
-        __block NSString *factoryPath;
-        __block CDTDatastoreManager *factory;
+    beforeEach(^{
+        // Create a new CDTDatastoreFactory at a temp path
+
+        NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
+            stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+        const char *tempDirectoryTemplateCString = [tempDirectoryTemplate fileSystemRepresentation];
+        char *tempDirectoryNameCString = (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+        strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+
+        char *result = mkdtemp(tempDirectoryNameCString);
+        expect(result).to.beTruthy();
+
+        factoryPath = [[NSFileManager defaultManager]
+            stringWithFileSystemRepresentation:tempDirectoryNameCString
+                                        length:strlen(result)];
+        free(tempDirectoryNameCString);
+
+        NSError *error;
+        factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+    });
+
+    afterEach(^{
+        // Delete the databases we used
+
+        factory = nil;
+        NSError *error;
+        [[NSFileManager defaultManager] removeItemAtPath:factoryPath error:&error];
+    });
+
+    describe(@"when creating a tree", ^{
+
+        __block CDTDatastore *ds;
+        __block CDTQIndexManager *im;
+        __block NSDictionary *indexes;
 
         beforeEach(^{
-            // Create a new CDTDatastoreFactory at a temp path
+            ds = [factory datastoreNamed:@"test" error:nil];
+            im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
 
-            NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
-                stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
-            const char *tempDirectoryTemplateCString =
-                [tempDirectoryTemplate fileSystemRepresentation];
-            char *tempDirectoryNameCString =
-                (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
-            strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+            [im ensureIndexed:@[ @"name", @"age", @"pet" ] withName:@"basic"];
 
-            char *result = mkdtemp(tempDirectoryNameCString);
-            expect(result).to.beTruthy();
-
-            factoryPath = [[NSFileManager defaultManager]
-                stringWithFileSystemRepresentation:tempDirectoryNameCString
-                                            length:strlen(result)];
-            free(tempDirectoryNameCString);
-
-            NSError *error;
-            factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+            indexes = [im listIndexes];
         });
 
-        afterEach(^{
-            // Delete the databases we used
+        it(@"can cope with single level ANDed query", ^{
+            BOOL indexesCoverQuery;
+            NSDictionary *query = [CDTQQueryValidator normaliseAndValidateQuery:@{ @"name" : @"mike" }];
+            CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
+                                                            toUseIndexes:indexes
+                                                       indexesCoverQuery:&indexesCoverQuery];
+            expect(node).to.beInstanceOf([CDTQAndQueryNode class]);
+            expect(indexesCoverQuery).to.beTruthy();
 
-            factory = nil;
-            NSError *error;
-            [[NSFileManager defaultManager] removeItemAtPath:factoryPath error:&error];
+            CDTQAndQueryNode *and = (CDTQAndQueryNode *)node;
+            expect(and.children.count).to.equal(1);
+
+            CDTQSqlQueryNode *sqlNode = and.children[0];
+            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                             "WHERE \"name\" = ?;";
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
         });
 
-        describe(@"when creating a tree", ^{
+        it(@"can cope with single level ANDed query", ^{
+            BOOL indexesCoverQuery;
+            NSDictionary *query = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"name" : @"mike",
+                @"pet" : @"cat"
+            }];
+            CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
+                                                            toUseIndexes:indexes
+                                                       indexesCoverQuery:&indexesCoverQuery];
+            expect(node).to.beInstanceOf([CDTQAndQueryNode class]);
+            expect(indexesCoverQuery).to.beTruthy();
 
-            __block CDTDatastore *ds;
-            __block CDTQIndexManager *im;
-            __block NSDictionary *indexes;
+            CDTQAndQueryNode *and = (CDTQAndQueryNode *)node;
+            expect(and.children.count).to.equal(1);
 
-            beforeEach(^{
-                ds = [factory datastoreNamed:@"test" error:nil];
-                im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+            CDTQSqlQueryNode *sqlNode = and.children[0];
+            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                             "WHERE \"pet\" = ? AND \"name\" = ?;";
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat", @"mike" ]);
+        });
 
-                [im ensureIndexed:@[ @"name", @"age", @"pet" ] withName:@"basic"];
+        it(@"can cope with longhand single level ANDed query", ^{
+            BOOL indexesCoverQuery;
+            NSDictionary *query = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"$and" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]
+            }];
+            CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
+                                                            toUseIndexes:indexes
+                                                       indexesCoverQuery:&indexesCoverQuery];
+            expect(node).to.beInstanceOf([CDTQAndQueryNode class]);
+            expect(indexesCoverQuery).to.beTruthy();
 
-                indexes = [im listIndexes];
-            });
+            CDTQAndQueryNode *and = (CDTQAndQueryNode *)node;
+            expect(and.children.count).to.equal(1);
 
-            it(@"can cope with single level ANDed query", ^{
-                BOOL indexesCoverQuery;
-                CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:@{
-                    @"name" : @"mike"
-                } toUseIndexes:indexes indexesCoverQuery:&indexesCoverQuery];
-                expect(node).to.beInstanceOf([CDTQAndQueryNode class]);
-                expect(indexesCoverQuery).to.beTruthy();
+            CDTQSqlQueryNode *sqlNode = and.children[0];
+            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                             "WHERE \"name\" = ? AND \"pet\" = ?;";
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
+        });
 
-                CDTQAndQueryNode *and = (CDTQAndQueryNode *)node;
-                expect(and.children.count).to.equal(1);
+        it(@"can cope with longhand two level ANDed query", ^{
+            NSDictionary *query = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"$and" : @[
+                    @{@"name" : @"mike"},
+                    @{@"pet" : @"cat"},
+                    @{@"$and" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]}
+                ]
+            }];
+            BOOL indexesCoverQuery;
+            CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
+                                                            toUseIndexes:indexes
+                                                       indexesCoverQuery:&indexesCoverQuery];
+            expect(node).to.beInstanceOf([CDTQAndQueryNode class]);
+            expect(indexesCoverQuery).to.beTruthy();
 
-                CDTQSqlQueryNode *sqlNode = and.children[0];
-                NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
-                                 "WHERE \"name\" = ?;";
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
-            });
-
-            it(@"can cope with single level ANDed query", ^{
-                BOOL indexesCoverQuery;
-                CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:@{
-                    @"name" : @"mike",
-                    @"pet" : @"cat"
-                } toUseIndexes:indexes indexesCoverQuery:&indexesCoverQuery];
-                expect(node).to.beInstanceOf([CDTQAndQueryNode class]);
-                expect(indexesCoverQuery).to.beTruthy();
-
-                CDTQAndQueryNode *and = (CDTQAndQueryNode *)node;
-                expect(and.children.count).to.equal(1);
-
-                CDTQSqlQueryNode *sqlNode = and.children[0];
-                NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
-                                 "WHERE \"pet\" = ? AND \"name\" = ?;";
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat", @"mike" ]);
-            });
-
-            it(@"can cope with longhand single level ANDed query", ^{
-                BOOL indexesCoverQuery;
-                NSDictionary *query = @{ @"$and" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ] };
-                CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
-                                                                toUseIndexes:indexes
-                                                           indexesCoverQuery:&indexesCoverQuery];
-                expect(node).to.beInstanceOf([CDTQAndQueryNode class]);
-                expect(indexesCoverQuery).to.beTruthy();
-
-                CDTQAndQueryNode *and = (CDTQAndQueryNode *)node;
-                expect(and.children.count).to.equal(1);
-
-                CDTQSqlQueryNode *sqlNode = and.children[0];
-                NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
-                                 "WHERE \"name\" = ? AND \"pet\" = ?;";
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
-            });
-
-            it(@"can cope with longhand two level ANDed query", ^{
-                NSDictionary *query = @{
-                    @"$and" : @[
-                        @{@"name" : @"mike"},
-                        @{@"pet" : @"cat"},
-                        @{@"$and" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]}
-                    ]
-                };
-                BOOL indexesCoverQuery;
-                CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
-                                                                toUseIndexes:indexes
-                                                           indexesCoverQuery:&indexesCoverQuery];
-                expect(node).to.beInstanceOf([CDTQAndQueryNode class]);
-                expect(indexesCoverQuery).to.beTruthy();
-
-                //        AND
-                //       /   \
+            //        AND
+            //       /   \
             //      sql  AND
-                //             \
+            //             \
             //             sql
 
-                CDTQAndQueryNode *and = (CDTQAndQueryNode *)node;
-                expect(and.children.count).to.equal(2);
+            CDTQAndQueryNode *and = (CDTQAndQueryNode *)node;
+            expect(and.children.count).to.equal(2);
 
-                NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
-                                 "WHERE \"name\" = ? AND \"pet\" = ?;";
+            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                             "WHERE \"name\" = ? AND \"pet\" = ?;";
 
-                // As the embedded AND is the same as the top-level AND, both
-                // children should have the same embedded SQL.
+            // As the embedded AND is the same as the top-level AND, both
+            // children should have the same embedded SQL.
 
-                CDTQSqlQueryNode *sqlNode = and.children[0];
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
+            CDTQSqlQueryNode *sqlNode = and.children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
 
-                sqlNode = ((CDTQAndQueryNode *)and.children[1]).children[0];
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
-            });
+            sqlNode = ((CDTQAndQueryNode *)and.children[1]).children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
+        });
 
-            it(@"orders AND nodes last in trees", ^{
-                BOOL indexesCoverQuery;
-                NSDictionary *query = @{
-                    @"$and" : @[
-                        @{@"$and" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]},
-                        @{@"name" : @"mike"},
-                        @{@"pet" : @"cat"}
-                    ]
-                };
-                CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
-                                                                toUseIndexes:indexes
-                                                           indexesCoverQuery:&indexesCoverQuery];
-                expect(node).to.beInstanceOf([CDTQAndQueryNode class]);
-                expect(indexesCoverQuery).to.beTruthy();
+        it(@"orders AND nodes last in trees", ^{
+            BOOL indexesCoverQuery;
+            NSDictionary *query = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"$and" : @[
+                    @{@"$and" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]},
+                    @{@"name" : @"mike"},
+                    @{@"pet" : @"cat"}
+                ]
+            }];
+            CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
+                                                            toUseIndexes:indexes
+                                                       indexesCoverQuery:&indexesCoverQuery];
+            expect(node).to.beInstanceOf([CDTQAndQueryNode class]);
+            expect(indexesCoverQuery).to.beTruthy();
 
-                //        AND
-                //       /   \
+            //        AND
+            //       /   \
             //      sql  AND
-                //             \
+            //             \
             //             sql
 
-                CDTQAndQueryNode *and = (CDTQAndQueryNode *)node;
-                expect(and.children.count).to.equal(2);
+            CDTQAndQueryNode *and = (CDTQAndQueryNode *)node;
+            expect(and.children.count).to.equal(2);
 
-                NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
-                                 "WHERE \"name\" = ? AND \"pet\" = ?;";
+            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                             "WHERE \"name\" = ? AND \"pet\" = ?;";
 
-                // As the embedded AND is the same as the top-level AND, both
-                // children should have the same embedded SQL.
+            // As the embedded AND is the same as the top-level AND, both
+            // children should have the same embedded SQL.
 
-                CDTQSqlQueryNode *sqlNode = and.children[0];
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
+            CDTQSqlQueryNode *sqlNode = and.children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
 
-                sqlNode = ((CDTQAndQueryNode *)and.children[1]).children[0];
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
-            });
+            sqlNode = ((CDTQAndQueryNode *)and.children[1]).children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
+        });
 
-            it(@"supports using OR", ^{
-                NSDictionary *query = @{ @"$or" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ] };
-                BOOL indexesCoverQuery;
-                CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
-                                                                toUseIndexes:indexes
-                                                           indexesCoverQuery:&indexesCoverQuery];
-                expect(node).to.beInstanceOf([CDTQOrQueryNode class]);
-                expect(indexesCoverQuery).to.beTruthy();
+        it(@"supports using OR", ^{
+            NSDictionary *query = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"$or" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]
+            }];
+            BOOL indexesCoverQuery;
+            CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
+                                                            toUseIndexes:indexes
+                                                       indexesCoverQuery:&indexesCoverQuery];
+            expect(node).to.beInstanceOf([CDTQOrQueryNode class]);
+            expect(indexesCoverQuery).to.beTruthy();
 
-                //        _OR_
-                //       /    \
+            //        _OR_
+            //       /    \
             //      sql   sql
 
-                CDTQOrQueryNode * or = (CDTQOrQueryNode *)node;
-                expect(or .children.count).to.equal(2);
+            CDTQOrQueryNode * or = (CDTQOrQueryNode *)node;
+            expect(or .children.count).to.equal(2);
 
-                NSString *sqlLeft = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
-                                     "WHERE \"name\" = ?;";
+            NSString *sqlLeft = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                                 "WHERE \"name\" = ?;";
 
-                NSString *sqlRight = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
-                                      "WHERE \"pet\" = ?;";
+            NSString *sqlRight = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                                  "WHERE \"pet\" = ?;";
 
-                CDTQSqlQueryNode *sqlNode;
+            CDTQSqlQueryNode *sqlNode;
 
-                sqlNode = or .children[0];
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlLeft);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
+            sqlNode = or .children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlLeft);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
 
-                sqlNode = or .children[1];
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlRight);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat" ]);
-            });
+            sqlNode = or .children[1];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlRight);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat" ]);
+        });
 
-            it(@"supports using OR in sub trees", ^{
-                NSDictionary *query = @{
-                    @"$or" : @[
-                        @{@"name" : @"mike"},
-                        @{@"pet" : @"cat"},
-                        @{@"$or" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]}
-                    ]
-                };
-                BOOL indexesCoverQuery;
-                CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
-                                                                toUseIndexes:indexes
-                                                           indexesCoverQuery:&indexesCoverQuery];
-                expect(node).to.beInstanceOf([CDTQOrQueryNode class]);
-                expect(indexesCoverQuery).to.beTruthy();
+        it(@"supports using OR in sub trees", ^{
+            NSDictionary *query = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"$or" : @[
+                    @{@"name" : @"mike"},
+                    @{@"pet" : @"cat"},
+                    @{@"$or" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]}
+                ]
+            }];
+            BOOL indexesCoverQuery;
+            CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
+                                                            toUseIndexes:indexes
+                                                       indexesCoverQuery:&indexesCoverQuery];
+            expect(node).to.beInstanceOf([CDTQOrQueryNode class]);
+            expect(indexesCoverQuery).to.beTruthy();
 
-                //        OR______
-                //       /   \    \
+            //        OR______
+            //       /   \    \
             //      sql  sql  OR
-                //               /  \
+            //               /  \
             //             sql  sql
 
-                CDTQOrQueryNode * or = (CDTQOrQueryNode *)node;
-                expect(or .children.count).to.equal(3);
+            CDTQOrQueryNode * or = (CDTQOrQueryNode *)node;
+            expect(or .children.count).to.equal(3);
 
-                NSString *sqlLeft = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
-                                     "WHERE \"name\" = ?;";
+            NSString *sqlLeft = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                                 "WHERE \"name\" = ?;";
 
-                NSString *sqlRight = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
-                                      "WHERE \"pet\" = ?;";
+            NSString *sqlRight = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                                  "WHERE \"pet\" = ?;";
 
-                CDTQSqlQueryNode *sqlNode;
+            CDTQSqlQueryNode *sqlNode;
 
-                sqlNode = or .children[0];
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlLeft);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
+            sqlNode = or .children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlLeft);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
 
-                sqlNode = or .children[1];
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlRight);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat" ]);
+            sqlNode = or .children[1];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlRight);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat" ]);
 
-                CDTQOrQueryNode *subOr = (CDTQOrQueryNode *) or .children[2];
-                expect(subOr).to.beInstanceOf([CDTQOrQueryNode class]);
+            CDTQOrQueryNode *subOr = (CDTQOrQueryNode *) or .children[2];
+            expect(subOr).to.beInstanceOf([CDTQOrQueryNode class]);
 
-                sqlNode = subOr.children[0];
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlLeft);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
+            sqlNode = subOr.children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlLeft);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
 
-                sqlNode = subOr.children[1];
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlRight);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat" ]);
-            });
+            sqlNode = subOr.children[1];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlRight);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat" ]);
+        });
 
-            it(@"supports using AND and OR in sub trees", ^{
-                NSDictionary *query = @{
-                    @"$or" : @[
-                        @{@"name" : @"mike"},
-                        @{@"pet" : @"cat"},
-                        @{@"$or" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]},
-                        @{@"$and" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]}
-                    ]
-                };
-                BOOL indexesCoverQuery;
-                CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
-                                                                toUseIndexes:indexes
-                                                           indexesCoverQuery:&indexesCoverQuery];
-                expect(node).to.beInstanceOf([CDTQOrQueryNode class]);
-                expect(indexesCoverQuery).to.beTruthy();
+        it(@"supports using AND and OR in sub trees", ^{
+            NSDictionary *query = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"$or" : @[
+                    @{@"name" : @"mike"},
+                    @{@"pet" : @"cat"},
+                    @{@"$or" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]},
+                    @{@"$and" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]}
+                ]
+            }];
+            BOOL indexesCoverQuery;
+            CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
+                                                            toUseIndexes:indexes
+                                                       indexesCoverQuery:&indexesCoverQuery];
+            expect(node).to.beInstanceOf([CDTQOrQueryNode class]);
+            expect(indexesCoverQuery).to.beTruthy();
 
-                //        OR____________
-                //       /   \    \     \
+            //        OR____________
+            //       /   \    \     \
             //      sql  sql  OR    AND
-                //               /  \     \
+            //               /  \     \
             //             sql  sql   sql
 
-                CDTQOrQueryNode * or = (CDTQOrQueryNode *)node;
-                expect(or .children.count).to.equal(4);
+            CDTQOrQueryNode * or = (CDTQOrQueryNode *)node;
+            expect(or .children.count).to.equal(4);
 
-                NSString *sqlLeft = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
-                                     "WHERE \"name\" = ?;";
-
-                NSString *sqlRight = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
-                                      "WHERE \"pet\" = ?;";
-
-                NSString *sqlAnd = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
-                                    "WHERE \"name\" = ? AND \"pet\" = ?;";
-
-                CDTQSqlQueryNode *sqlNode;
-
-                sqlNode = or .children[0];
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlLeft);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
-
-                sqlNode = or .children[1];
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlRight);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat" ]);
-
-                CDTQOrQueryNode *subOr = (CDTQOrQueryNode *) or .children[2];
-                expect(subOr).to.beInstanceOf([CDTQOrQueryNode class]);
-                expect(subOr.children.count).to.equal(2);
-
-                sqlNode = subOr.children[0];
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlLeft);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
-
-                sqlNode = subOr.children[1];
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlRight);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat" ]);
-
-                CDTQAndQueryNode *subAnd = (CDTQAndQueryNode *) or .children[3];
-                expect(subAnd).to.beInstanceOf([CDTQAndQueryNode class]);
-                expect(subAnd.children.count).to.equal(1);
-
-                sqlNode = subAnd.children[0];
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlAnd);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
-            });
-
-            it(@"supports using AND and OR in sub trees", ^{
-                NSDictionary *query = @{
-                    @"$or" : @[
-                        @{@"name" : @"mike"},
-                        @{@"pet" : @"cat"},
-                        @{
-                           @"$or" : @[
-                               @{@"name" : @"mike"},
-                               @{@"pet" : @"cat"},
-                               @{@"$and" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]}
-                           ]
-                        }
-                    ]
-                };
-                BOOL indexesCoverQuery;
-                CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
-                                                                toUseIndexes:indexes
-                                                           indexesCoverQuery:&indexesCoverQuery];
-                expect(node).to.beInstanceOf([CDTQOrQueryNode class]);
-                expect(indexesCoverQuery).to.beTruthy();
-
-                //        OR______
-                //       /   \    \
-            //      sql  sql  OR______
-                //               /  \     \
-            //             sql  sql   AND
-                //                         |
-                //                        sql
-
-                CDTQOrQueryNode * or = (CDTQOrQueryNode *)node;
-                expect(or .children.count).to.equal(3);
-
-                NSString *sqlLeft = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
-                                     "WHERE \"name\" = ?;";
-
-                NSString *sqlRight = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
-                                      "WHERE \"pet\" = ?;";
-
-                NSString *sqlAnd = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
-                                    "WHERE \"name\" = ? AND \"pet\" = ?;";
-
-                CDTQSqlQueryNode *sqlNode;
-
-                sqlNode = or .children[0];
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlLeft);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
-
-                sqlNode = or .children[1];
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlRight);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat" ]);
-
-                CDTQOrQueryNode *subOr = (CDTQOrQueryNode *) or .children[2];
-                expect(subOr).to.beInstanceOf([CDTQOrQueryNode class]);
-                expect(subOr.children.count).to.equal(3);
-
-                sqlNode = subOr.children[0];
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlLeft);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
-
-                sqlNode = subOr.children[1];
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlRight);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat" ]);
-
-                CDTQAndQueryNode *subAnd = (CDTQAndQueryNode *)subOr.children[2];
-                expect(subAnd).to.beInstanceOf([CDTQAndQueryNode class]);
-                expect(subAnd.children.count).to.equal(1);
-
-                sqlNode = subAnd.children[0];
-                expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlAnd);
-                expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
-            });
-
-        });
-
-        describe(@"when selecting an index to use", ^{
-
-            __block CDTDatastore *ds;
-            __block CDTQIndexManager *im;
-
-            beforeEach(^{
-                ds = [factory datastoreNamed:@"test" error:nil];
-                im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
-            });
-
-            it(@"fails if no indexes available", ^{
-                expect([CDTQQuerySqlTranslator chooseIndexForAndClause:@[
-                           @{ @"name" : @"mike" }
-                       ] fromIndexes:@{}]).to.beNil();
-            });
-
-            it(@"fails if no keys in query", ^{
-                NSDictionary *indexes = @{ @"named" : @[ @"name", @"age", @"pet" ] };
-                expect(
-                    [CDTQQuerySqlTranslator chooseIndexForAndClause:@[ @{} ] fromIndexes:indexes])
-                    .to.beNil();
-            });
-
-            it(@"selects an index for single field queries", ^{
-                NSDictionary *indexes = @{
-                    @"named" : @{@"name" : @"named", @"type" : @"json", @"fields" : @[ @"name" ]}
-                };
-                NSString *idx = [CDTQQuerySqlTranslator chooseIndexForAndClause:@[
-                    @{ @"name" : @"mike" }
-                ] fromIndexes:indexes];
-                expect(idx).to.equal(@"named");
-            });
-
-            it(@"selects an index for multi-field queries", ^{
-                NSDictionary *indexes = @{
-                    @"named" : @{
-                        @"name" : @"named",
-                        @"type" : @"json",
-                        @"fields" : @[ @"name", @"age", @"pet" ]
-                    }
-                };
-                NSString *idx = [CDTQQuerySqlTranslator
-                    chooseIndexForAndClause:@[ @{ @"name" : @"mike" }, @{
-                        @"pet" : @"cat"
-                    } ] fromIndexes:indexes];
-                expect(idx).to.equal(@"named");
-            });
-
-            it(@"selects an index from several indexes for multi-field queries", ^{
-                NSDictionary *indexes = @{
-                    @"named" : @{
-                        @"name" : @"named",
-                        @"type" : @"json",
-                        @"fields" : @[ @"name", @"age", @"pet" ]
-                    },
-                    @"bopped" : @{
-                        @"name" : @"named",
-                        @"type" : @"json",
-                        @"fields" : @[ @"house_number", @"pet" ]
-                    },
-                    @"unsuitable" :
-                        @{@"name" : @"named", @"type" : @"json", @"fields" : @[ @"name" ]},
-                };
-                NSString *idx = [CDTQQuerySqlTranslator
-                    chooseIndexForAndClause:@[ @{ @"name" : @"mike" }, @{
-                        @"pet" : @"cat"
-                    } ] fromIndexes:indexes];
-                expect(idx).to.equal(@"named");
-            });
-
-            it(@"selects an correct index when several match", ^{
-                NSDictionary *indexes = @{
-                    @"named" : @{
-                        @"name" : @"named",
-                        @"type" : @"json",
-                        @"fields" : @[ @"name", @"age", @"pet" ]
-                    },
-                    @"bopped" : @{
-                        @"name" : @"named",
-                        @"type" : @"json",
-                        @"fields" : @[ @"name", @"age", @"pet" ]
-                    },
-                    @"many_field" : @{
-                        @"name" : @"named",
-                        @"type" : @"json",
-                        @"fields" : @[ @"name", @"age", @"pet", @"car", @"van" ]
-                    },
-                    @"unsuitable" :
-                        @{@"name" : @"named", @"type" : @"json", @"fields" : @[ @"name" ]},
-                };
-                NSString *idx = [CDTQQuerySqlTranslator
-                    chooseIndexForAndClause:@[ @{ @"name" : @"mike" }, @{
-                        @"pet" : @"cat"
-                    } ] fromIndexes:indexes];
-                expect([@[ @"named", @"bopped" ] containsObject:idx]).to.beTruthy();
-            });
-
-            it(@"fails if no suitable index is available", ^{
-                NSDictionary *indexes = @{
-                    @"named" :
-                        @{@"name" : @"named", @"type" : @"json", @"fields" : @[ @"name", @"age" ]},
-                    @"unsuitable" :
-                        @{@"name" : @"named", @"type" : @"json", @"fields" : @[ @"name" ]},
-                };
-                expect([CDTQQuerySqlTranslator chooseIndexForAndClause:@[
-                           @{ @"pet" : @"cat" }
-                       ] fromIndexes:indexes]).to.beNil();
-            });
-
-        });
-
-        describe(@"when generating query WHERE clauses", ^{
-
-            it(@"returns nil when no query terms", ^{
-                CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[]];
-                expect(parts).to.beNil();
-            });
-
-            describe(@"when using $eq operator", ^{
-
-                it(@"returns correctly for a single term", ^{
-                    CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[
-                        @{ @"name" : @{@"$eq" : @"mike"} }
-                    ]];
-                    expect(parts.sqlWithPlaceholders).to.equal(@"\"name\" = ?");
-                    expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
-                });
-
-                it(@"returns correctly for many query terms", ^{
-                    NSArray *query = @[
-                        @{ @"name" : @{@"$eq" : @"mike"} },
-                        @{ @"age" : @{@"$eq" : @12} },
-                        @{ @"pet" : @{@"$eq" : @"cat"} }
-                    ];
-                    CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:query];
-                    expect(parts.sqlWithPlaceholders)
-                        .to.equal(@"\"name\" = ? AND \"age\" = ? AND \"pet\" = ?");
-                    expect(parts.placeholderValues).to.equal(@[ @"mike", @12, @"cat" ]);
-                });
-
-            });
-
-            describe(@"when using unsupported operator", ^{
-                it(@"uses correct SQL operator", ^{
-                    CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[
-                        @{ @"name" : @{@"$blah" : @"mike"} }
-                    ]];
-                    expect(parts).to.beNil();
-                });
-            });
-
-            describe(@"when using $gt operator", ^{
-                it(@"uses correct SQL operator", ^{
-                    CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[
-                        @{ @"name" : @{@"$gt" : @"mike"} }
-                    ]];
-                    expect(parts.sqlWithPlaceholders).to.equal(@"\"name\" > ?");
-                });
-            });
-
-            describe(@"when using $gte operator", ^{
-                it(@"uses correct SQL operator", ^{
-                    CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[
-                        @{ @"name" : @{@"$gte" : @"mike"} }
-                    ]];
-                    expect(parts.sqlWithPlaceholders).to.equal(@"\"name\" >= ?");
-                });
-            });
-
-            describe(@"when using $lt operator", ^{
-                it(@"uses correct SQL operator", ^{
-                    CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[
-                        @{ @"name" : @{@"$lt" : @"mike"} }
-                    ]];
-                    expect(parts.sqlWithPlaceholders).to.equal(@"\"name\" < ?");
-                });
-            });
-
-            describe(@"when using $lte operator", ^{
-                it(@"uses correct SQL operator", ^{
-                    CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[
-                        @{ @"name" : @{@"$lte" : @"mike"} }
-                    ]];
-                    expect(parts.sqlWithPlaceholders).to.equal(@"\"name\" <= ?");
-                });
-            });
-
-            describe(@"when using $ne operator", ^{
-                it(@"uses correct SQL operator", ^{
-                    CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[
-                        @{ @"name" : @{@"$ne" : @"mike"} }
-                    ]];
-                    expect(parts.sqlWithPlaceholders).to.equal(@"\"name\" != ?");
-                });
-            });
-
-            describe(@"when using the $exists oprtator", ^{
-                it(@"uses correct SQL operator for $exits : true", ^{
-                    CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[
-                        @{ @"name" : @{@"$exists" : @YES} }
-                    ]];
-                    expect(parts.sqlWithPlaceholders).to.equal(@"(\"name\" IS NOT NULL)");
-                });
-                it(@"uses correct SQL operator for $exits : false:", ^{
-                    CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[
-                        @{ @"name" : @{@"$exists" : @NO} }
-                    ]];
-                    expect(parts.sqlWithPlaceholders).to.equal(@"(\"name\" IS NULL)");
-                });
-                it(@"uses correct SQL operator for $not { $exits : false}", ^{
-                    CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[
-                        @{ @"name" : @{@"$not" : @{@"$exists" : @NO}} }
-                    ]];
-                    expect(parts.sqlWithPlaceholders).to.equal(@"(\"name\" IS NOT NULL)");
-                });
-                it(@"uses correct SQL operator for $not {$exits : true}", ^{
-                    CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[
-                        @{ @"name" : @{@"$not" : @{@"$exists" : @YES}} }
-                    ]];
-                    expect(parts.sqlWithPlaceholders).to.equal(@"(\"name\" IS NULL)");
-                });
-            });
-        });
-
-        describe(@"when generating WHERE with $not", ^{
-
-            it(@"returns nil when no query terms", ^{
-                CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[]];
-                expect(parts).to.beNil();
-            });
-
-            describe(@"when using $eq operator", ^{
-
-                it(@"returns correctly for a single term", ^{
-                    CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[
-                        @{ @"name" : @{@"$not" : @{@"$eq" : @"mike"}} }
-                    ]];
-                    expect(parts.sqlWithPlaceholders)
-                        .to.equal(@"(\"name\" != ? OR \"name\" IS NULL)");
-                    expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
-                });
-
-                it(@"returns correctly for many query terms", ^{
-                    NSArray *query = @[
-                        @{ @"name" : @{@"$not" : @{@"$eq" : @"mike"}} },
-                        @{ @"age" : @{@"$eq" : @12} },
-                        @{ @"pet" : @{@"$not" : @{@"$eq" : @"cat"}} }
-                    ];
-                    CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:query];
-                    expect(parts.sqlWithPlaceholders)
-                        .to.equal(@"(\"name\" != ? OR \"name\" IS NULL) AND \"age\" = ? AND "
-                                  @"(\"pet\" != ? OR \"pet\" IS NULL)");
-                    expect(parts.placeholderValues).to.equal(@[ @"mike", @12, @"cat" ]);
-                });
-
-            });
-
-            describe(@"when using unsupported operator", ^{
-                it(@"uses correct SQL operator", ^{
-                    CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[
-                        @{ @"name" : @{@"$not" : @{@"$blah" : @"mike"}} }
-                    ]];
-                    expect(parts).to.beNil();
-                });
-            });
-
-            describe(@"when using $gt operator", ^{
-                it(@"uses correct SQL operator", ^{
-                    CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[
-                        @{ @"name" : @{@"$not" : @{@"$gt" : @"mike"}} }
-                    ]];
-                    expect(parts.sqlWithPlaceholders)
-                        .to.equal(@"(\"name\" <= ? OR \"name\" IS NULL)");
-                });
-            });
-
-            describe(@"when using $gte operator", ^{
-                it(@"uses correct SQL operator", ^{
-                    CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[
-                        @{ @"name" : @{@"$not" : @{@"$gte" : @"mike"}} }
-                    ]];
-                    expect(parts.sqlWithPlaceholders)
-                        .to.equal(@"(\"name\" < ? OR \"name\" IS NULL)");
-                });
-            });
-
-            describe(@"when using $lt operator", ^{
-                it(@"uses correct SQL operator", ^{
-                    CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[
-                        @{ @"name" : @{@"$not" : @{@"$lt" : @"mike"}} }
-                    ]];
-                    expect(parts.sqlWithPlaceholders)
-                        .to.equal(@"(\"name\" >= ? OR \"name\" IS NULL)");
-                });
-            });
-
-            describe(@"when using $lte operator", ^{
-                it(@"uses correct SQL operator", ^{
-                    CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[
-                        @{ @"name" : @{@"$not" : @{@"$lte" : @"mike"}} }
-                    ]];
-                    expect(parts.sqlWithPlaceholders)
-                        .to.equal(@"(\"name\" > ? OR \"name\" IS NULL)");
-                });
-            });
-
-            describe(@"when using $ne operator", ^{
-                it(@"uses correct SQL operator", ^{
-                    CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[
-                        @{ @"name" : @{@"$not" : @{@"$ne" : @"mike"}} }
-                    ]];
-                    expect(parts.sqlWithPlaceholders)
-                        .to.equal(@"(\"name\" = ? OR \"name\" IS NULL)");
-                });
-            });
-        });
-
-        describe(@"when multiple conditions on one field", ^{
-
-            it(@"returns correctly for a two conditions", ^{
-                NSArray *clause = @[
-                    @{ @"name" : @{@"$not" : @{@"$eq" : @"mike"}} },
-                    @{ @"name" : @{@"$eq" : @"john"} }
-                ];
-                CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:clause];
-                expect(parts.sqlWithPlaceholders)
-                    .to.equal(@"(\"name\" != ? OR \"name\" IS NULL) AND \"name\" = ?");
-                expect(parts.placeholderValues).to.equal(@[ @"mike", @"john" ]);
-            });
-
-            it(@"returns correctly for several conditions", ^{
-                NSArray *clause = @[
-                    @{ @"age" : @{@"$gt" : @12} },
-                    @{ @"age" : @{@"$lte" : @54} },
-                    @{ @"name" : @{@"$eq" : @"mike"} },
-                    @{ @"age" : @{@"$ne" : @30} },
-                    @{ @"age" : @{@"$eq" : @42} },
-                ];
-                CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:clause];
-                expect(parts.sqlWithPlaceholders).to.equal(@"\"age\" > ? AND \"age\" <= ? AND "
-                                                           @"\"name\" = ? AND \"age\" != ? AND "
-                                                           @"\"age\" = ?");
-                expect(parts.placeholderValues).to.equal(@[ @12, @54, @"mike", @30, @42 ]);
-            });
-
-        });
-
-        describe(@"when generating query SELECT clauses", ^{
-
-            it(@"returns nil for no query terms", ^{
-                CDTQSqlParts *parts =
-                    [CDTQQuerySqlTranslator selectStatementForAndClause:@[] usingIndex:@"named"];
-                expect(parts).to.beNil();
-            });
-
-            it(@"returns nil for no index name", ^{
-                CDTQSqlParts *parts = [CDTQQuerySqlTranslator selectStatementForAndClause:@[
-                    @{ @"name" : @{@"$eq" : @"mike"} }
-                ] usingIndex:nil];
-                expect(parts).to.beNil();
-            });
-
-            it(@"returns correctly for single query term", ^{
-                CDTQSqlParts *parts = [CDTQQuerySqlTranslator selectStatementForAndClause:@[
-                    @{ @"name" : @{@"$eq" : @"mike"} }
-                ] usingIndex:@"anIndex"];
-                NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_anIndex "
+            NSString *sqlLeft = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
                                  "WHERE \"name\" = ?;";
-                expect(parts.sqlWithPlaceholders).to.equal(sql);
+
+            NSString *sqlRight = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                                  "WHERE \"pet\" = ?;";
+
+            NSString *sqlAnd = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                                "WHERE \"name\" = ? AND \"pet\" = ?;";
+
+            CDTQSqlQueryNode *sqlNode;
+
+            sqlNode = or .children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlLeft);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
+
+            sqlNode = or .children[1];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlRight);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat" ]);
+
+            CDTQOrQueryNode *subOr = (CDTQOrQueryNode *) or .children[2];
+            expect(subOr).to.beInstanceOf([CDTQOrQueryNode class]);
+            expect(subOr.children.count).to.equal(2);
+
+            sqlNode = subOr.children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlLeft);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
+
+            sqlNode = subOr.children[1];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlRight);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat" ]);
+
+            CDTQAndQueryNode *subAnd = (CDTQAndQueryNode *) or .children[3];
+            expect(subAnd).to.beInstanceOf([CDTQAndQueryNode class]);
+            expect(subAnd.children.count).to.equal(1);
+
+            sqlNode = subAnd.children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlAnd);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
+        });
+
+        it(@"supports using AND and OR in sub trees", ^{
+            NSDictionary *query = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"$or" : @[
+                    @{@"name" : @"mike"},
+                    @{@"pet" : @"cat"},
+                    @{
+                       @"$or" : @[
+                           @{@"name" : @"mike"},
+                           @{@"pet" : @"cat"},
+                           @{@"$and" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]}
+                       ]
+                    }
+                ]
+            }];
+            BOOL indexesCoverQuery;
+            CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
+                                                            toUseIndexes:indexes
+                                                       indexesCoverQuery:&indexesCoverQuery];
+            expect(node).to.beInstanceOf([CDTQOrQueryNode class]);
+            expect(indexesCoverQuery).to.beTruthy();
+
+            //        OR______
+            //       /   \    \
+            //      sql  sql  OR______
+            //               /  \     \
+            //             sql  sql   AND
+            //                         |
+            //                        sql
+
+            CDTQOrQueryNode * or = (CDTQOrQueryNode *)node;
+            expect(or .children.count).to.equal(3);
+
+            NSString *sqlLeft = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                                 "WHERE \"name\" = ?;";
+
+            NSString *sqlRight = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                                  "WHERE \"pet\" = ?;";
+
+            NSString *sqlAnd = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                                "WHERE \"name\" = ? AND \"pet\" = ?;";
+
+            CDTQSqlQueryNode *sqlNode;
+
+            sqlNode = or .children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlLeft);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
+
+            sqlNode = or .children[1];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlRight);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat" ]);
+
+            CDTQOrQueryNode *subOr = (CDTQOrQueryNode *) or .children[2];
+            expect(subOr).to.beInstanceOf([CDTQOrQueryNode class]);
+            expect(subOr.children.count).to.equal(3);
+
+            sqlNode = subOr.children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlLeft);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
+
+            sqlNode = subOr.children[1];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlRight);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat" ]);
+
+            CDTQAndQueryNode *subAnd = (CDTQAndQueryNode *)subOr.children[2];
+            expect(subAnd).to.beInstanceOf([CDTQAndQueryNode class]);
+            expect(subAnd.children.count).to.equal(1);
+
+            sqlNode = subAnd.children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlAnd);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
+        });
+    });
+
+    describe(@"when selecting an index to use", ^{
+
+        __block CDTDatastore *ds;
+        __block CDTQIndexManager *im;
+
+        beforeEach(^{
+            ds = [factory datastoreNamed:@"test" error:nil];
+            im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+        });
+
+        it(@"fails if no indexes available", ^{
+            expect([CDTQQuerySqlTranslator chooseIndexForAndClause:@[
+                                                                      @{ @"name" : @"mike" }
+                                                                   ]
+                                                       fromIndexes:@{}]).to.beNil();
+        });
+
+        it(@"fails if no keys in query", ^{
+            NSDictionary *indexes = @{ @"named" : @[ @"name", @"age", @"pet" ] };
+            expect([CDTQQuerySqlTranslator chooseIndexForAndClause:@[ @{} ] fromIndexes:indexes])
+                .to.beNil();
+        });
+
+        it(@"selects an index for single field queries", ^{
+            NSDictionary *indexes = @{
+                @"named" : @{@"name" : @"named", @"type" : @"json", @"fields" : @[ @"name" ]}
+            };
+            NSString *idx =
+                [CDTQQuerySqlTranslator chooseIndexForAndClause:@[
+                                                                   @{ @"name" : @"mike" }
+                                                                ]
+                                                    fromIndexes:indexes];
+            expect(idx).to.equal(@"named");
+        });
+
+        it(@"selects an index for multi-field queries", ^{
+            NSDictionary *indexes = @{
+                @"named" : @{
+                    @"name" : @"named",
+                    @"type" : @"json",
+                    @"fields" : @[ @"name", @"age", @"pet" ]
+                }
+            };
+            NSString *idx = [CDTQQuerySqlTranslator
+                chooseIndexForAndClause:@[ @{ @"name" : @"mike" }, @{
+                                            @"pet" : @"cat"
+                                        } ]
+                            fromIndexes:indexes];
+            expect(idx).to.equal(@"named");
+        });
+
+        it(@"selects an index from several indexes for multi-field queries", ^{
+            NSDictionary *indexes = @{
+                @"named" : @{
+                    @"name" : @"named",
+                    @"type" : @"json",
+                    @"fields" : @[ @"name", @"age", @"pet" ]
+                },
+                @"bopped" : @{
+                    @"name" : @"named",
+                    @"type" : @"json",
+                    @"fields" : @[ @"house_number", @"pet" ]
+                },
+                @"unsuitable" : @{@"name" : @"named", @"type" : @"json", @"fields" : @[ @"name" ]},
+            };
+            NSString *idx = [CDTQQuerySqlTranslator
+                chooseIndexForAndClause:@[ @{ @"name" : @"mike" }, @{
+                                            @"pet" : @"cat"
+                                        } ]
+                            fromIndexes:indexes];
+            expect(idx).to.equal(@"named");
+        });
+
+        it(@"selects an correct index when several match", ^{
+            NSDictionary *indexes = @{
+                @"named" : @{
+                    @"name" : @"named",
+                    @"type" : @"json",
+                    @"fields" : @[ @"name", @"age", @"pet" ]
+                },
+                @"bopped" : @{
+                    @"name" : @"named",
+                    @"type" : @"json",
+                    @"fields" : @[ @"name", @"age", @"pet" ]
+                },
+                @"many_field" : @{
+                    @"name" : @"named",
+                    @"type" : @"json",
+                    @"fields" : @[ @"name", @"age", @"pet", @"car", @"van" ]
+                },
+                @"unsuitable" : @{@"name" : @"named", @"type" : @"json", @"fields" : @[ @"name" ]},
+            };
+            NSString *idx = [CDTQQuerySqlTranslator
+                chooseIndexForAndClause:@[ @{ @"name" : @"mike" }, @{
+                                            @"pet" : @"cat"
+                                        } ]
+                            fromIndexes:indexes];
+            expect([@[ @"named", @"bopped" ] containsObject:idx]).to.beTruthy();
+        });
+
+        it(@"fails if no suitable index is available", ^{
+            NSDictionary *indexes = @{
+                @"named" :
+                    @{@"name" : @"named", @"type" : @"json", @"fields" : @[ @"name", @"age" ]},
+                @"unsuitable" : @{@"name" : @"named", @"type" : @"json", @"fields" : @[ @"name" ]},
+            };
+            expect([CDTQQuerySqlTranslator chooseIndexForAndClause:@[
+                                                                      @{ @"pet" : @"cat" }
+                                                                   ]
+                                                       fromIndexes:indexes]).to.beNil();
+        });
+    });
+
+    describe(@"when generating query WHERE clauses", ^{
+
+        it(@"returns nil when no query terms", ^{
+            CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[]];
+            expect(parts).to.beNil();
+        });
+
+        describe(@"when using $eq operator", ^{
+
+            it(@"returns correctly for a single term", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$eq" : @"mike"} }
+                                           ]];
+                expect(parts.sqlWithPlaceholders).to.equal(@"\"name\" = ?");
                 expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
             });
 
             it(@"returns correctly for many query terms", ^{
-                NSArray *andClause = @[
+                NSArray *query = @[
                     @{ @"name" : @{@"$eq" : @"mike"} },
                     @{ @"age" : @{@"$eq" : @12} },
                     @{ @"pet" : @{@"$eq" : @"cat"} }
                 ];
-                CDTQSqlParts *parts =
-                    [CDTQQuerySqlTranslator selectStatementForAndClause:andClause
-                                                             usingIndex:@"anIndex"];
-                NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_anIndex "
-                                 "WHERE \"name\" = ? AND \"age\" = ? AND \"pet\" = ?;";
-                expect(parts.sqlWithPlaceholders).to.equal(sql);
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:query];
+                expect(parts.sqlWithPlaceholders)
+                    .to.equal(@"\"name\" = ? AND \"age\" = ? AND \"pet\" = ?");
                 expect(parts.placeholderValues).to.equal(@[ @"mike", @12, @"cat" ]);
             });
-
         });
 
-        describe(@"when normalising queries", ^{
-
-            it(@"expands top-level implicit $and single field", ^{
-                NSDictionary *actual = [CDTQQuerySqlTranslator normaliseQuery:@{
-                    @"name" : @"mike"
-                }];
-                expect(actual).to.equal(@{ @"$and" : @[ @{@"name" : @{@"$eq" : @"mike"}} ] });
+        describe(@"when using unsupported operator", ^{
+            it(@"uses correct SQL operator", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$blah" : @"mike"} }
+                                           ]];
+                expect(parts).to.beNil();
             });
-
-            it(@"expands top-level implicit $and multi field", ^{
-                NSDictionary *actual = [CDTQQuerySqlTranslator normaliseQuery:@{
-                    @"name" : @"mike",
-                    @"pet" : @"cat",
-                    @"age" : @12
-                }];
-                expect(actual).to.equal(@{
-                    @"$and" : @[
-                        @{@"pet" : @{@"$eq" : @"cat"}},
-                        @{@"name" : @{@"$eq" : @"mike"}},
-                        @{@"age" : @{@"$eq" : @12}}
-                    ]
-                });
-            });
-
-            it(@"doesn't change already normalised query", ^{
-                NSDictionary *actual = [CDTQQuerySqlTranslator normaliseQuery:@{
-                    @"$and" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"}, @{@"age" : @12} ]
-                }];
-                expect(actual).to.equal(@{
-                    @"$and" : @[
-                        @{@"name" : @{@"$eq" : @"mike"}},
-                        @{@"pet" : @{@"$eq" : @"cat"}},
-                        @{@"age" : @{@"$eq" : @12}}
-                    ]
-                });
-            });
-
         });
 
-        describe(@"when extracting and clause field names", ^{
-
-            it(@"extracts a no field names", ^{
-                NSArray *fields = [CDTQQuerySqlTranslator fieldsForAndClause:@[]];
-                expect(fields).to.equal(@[]);
+        describe(@"when using $gt operator", ^{
+            it(@"uses correct SQL operator", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$gt" : @"mike"} }
+                                           ]];
+                expect(parts.sqlWithPlaceholders).to.equal(@"\"name\" > ?");
             });
-
-            it(@"extracts a single field name", ^{
-                NSArray *fields = [CDTQQuerySqlTranslator fieldsForAndClause:@[
-                    @{ @"name" : @"mike" }
-                ]];
-                expect(fields).to.equal(@[ @"name" ]);
-            });
-
-            it(@"extracts a multiple field names", ^{
-                NSArray *fields = [CDTQQuerySqlTranslator fieldsForAndClause:@[
-                    @{ @"name" : @"mike" },
-                    @{ @"pet" : @"cat" },
-                    @{ @"age" : @12 }
-                ]];
-                expect(fields).to.equal(@[ @"name", @"pet", @"age" ]);
-            });
-
         });
 
+        describe(@"when using $gte operator", ^{
+            it(@"uses correct SQL operator", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$gte" : @"mike"} }
+                                           ]];
+                expect(parts.sqlWithPlaceholders).to.equal(@"\"name\" >= ?");
+            });
+        });
+
+        describe(@"when using $lt operator", ^{
+            it(@"uses correct SQL operator", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$lt" : @"mike"} }
+                                           ]];
+                expect(parts.sqlWithPlaceholders).to.equal(@"\"name\" < ?");
+            });
+        });
+
+        describe(@"when using $lte operator", ^{
+            it(@"uses correct SQL operator", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$lte" : @"mike"} }
+                                           ]];
+                expect(parts.sqlWithPlaceholders).to.equal(@"\"name\" <= ?");
+            });
+        });
+
+        describe(@"when using $ne operator", ^{
+            it(@"uses correct SQL operator", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$ne" : @"mike"} }
+                                           ]];
+                expect(parts.sqlWithPlaceholders).to.equal(@"\"name\" != ?");
+            });
+        });
+
+        describe(@"when using the $exists oprtator", ^{
+            it(@"uses correct SQL operator for $exits : true", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$exists" : @YES} }
+                                           ]];
+                expect(parts.sqlWithPlaceholders).to.equal(@"(\"name\" IS NOT NULL)");
+            });
+            it(@"uses correct SQL operator for $exits : false:", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$exists" : @NO} }
+                                           ]];
+                expect(parts.sqlWithPlaceholders).to.equal(@"(\"name\" IS NULL)");
+            });
+            it(@"uses correct SQL operator for $not { $exits : false}", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$not" : @{@"$exists" : @NO}} }
+                                           ]];
+                expect(parts.sqlWithPlaceholders).to.equal(@"(\"name\" IS NOT NULL)");
+            });
+            it(@"uses correct SQL operator for $not {$exits : true}", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$not" : @{@"$exists" : @YES}} }
+                                           ]];
+                expect(parts.sqlWithPlaceholders).to.equal(@"(\"name\" IS NULL)");
+            });
+        });
     });
+
+    describe(@"when generating WHERE with $not", ^{
+
+        it(@"returns nil when no query terms", ^{
+            CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[]];
+            expect(parts).to.beNil();
+        });
+
+        describe(@"when using $eq operator", ^{
+
+            it(@"returns correctly for a single term", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$not" : @{@"$eq" : @"mike"}} }
+                                           ]];
+                expect(parts.sqlWithPlaceholders).to.equal(@"(\"name\" != ? OR \"name\" IS NULL)");
+                expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
+            });
+
+            it(@"returns correctly for many query terms", ^{
+                NSArray *query = @[
+                    @{ @"name" : @{@"$not" : @{@"$eq" : @"mike"}} },
+                    @{ @"age" : @{@"$eq" : @12} },
+                    @{ @"pet" : @{@"$not" : @{@"$eq" : @"cat"}} }
+                ];
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:query];
+                expect(parts.sqlWithPlaceholders)
+                    .to.equal(@"(\"name\" != ? OR \"name\" IS NULL) AND \"age\" = ? AND "
+                              @"(\"pet\" != ? OR \"pet\" IS NULL)");
+                expect(parts.placeholderValues).to.equal(@[ @"mike", @12, @"cat" ]);
+            });
+        });
+
+        describe(@"when using unsupported operator", ^{
+            it(@"uses correct SQL operator", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$not" : @{@"$blah" : @"mike"}} }
+                                           ]];
+                expect(parts).to.beNil();
+            });
+        });
+
+        describe(@"when using $gt operator", ^{
+            it(@"uses correct SQL operator", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$not" : @{@"$gt" : @"mike"}} }
+                                           ]];
+                expect(parts.sqlWithPlaceholders).to.equal(@"(\"name\" <= ? OR \"name\" IS NULL)");
+            });
+        });
+
+        describe(@"when using $gte operator", ^{
+            it(@"uses correct SQL operator", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$not" : @{@"$gte" : @"mike"}} }
+                                           ]];
+                expect(parts.sqlWithPlaceholders).to.equal(@"(\"name\" < ? OR \"name\" IS NULL)");
+            });
+        });
+
+        describe(@"when using $lt operator", ^{
+            it(@"uses correct SQL operator", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$not" : @{@"$lt" : @"mike"}} }
+                                           ]];
+                expect(parts.sqlWithPlaceholders).to.equal(@"(\"name\" >= ? OR \"name\" IS NULL)");
+            });
+        });
+
+        describe(@"when using $lte operator", ^{
+            it(@"uses correct SQL operator", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$not" : @{@"$lte" : @"mike"}} }
+                                           ]];
+                expect(parts.sqlWithPlaceholders).to.equal(@"(\"name\" > ? OR \"name\" IS NULL)");
+            });
+        });
+
+        describe(@"when using $ne operator", ^{
+            it(@"uses correct SQL operator", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$not" : @{@"$ne" : @"mike"}} }
+                                           ]];
+                expect(parts.sqlWithPlaceholders).to.equal(@"(\"name\" = ? OR \"name\" IS NULL)");
+            });
+        });
+    });
+
+    describe(@"when multiple conditions on one field", ^{
+
+        it(@"returns correctly for a two conditions", ^{
+            NSArray *clause = @[
+                @{ @"name" : @{@"$not" : @{@"$eq" : @"mike"}} },
+                @{ @"name" : @{@"$eq" : @"john"} }
+            ];
+            CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:clause];
+            expect(parts.sqlWithPlaceholders)
+                .to.equal(@"(\"name\" != ? OR \"name\" IS NULL) AND \"name\" = ?");
+            expect(parts.placeholderValues).to.equal(@[ @"mike", @"john" ]);
+        });
+
+        it(@"returns correctly for several conditions", ^{
+            NSArray *clause = @[
+                @{ @"age" : @{@"$gt" : @12} },
+                @{ @"age" : @{@"$lte" : @54} },
+                @{ @"name" : @{@"$eq" : @"mike"} },
+                @{ @"age" : @{@"$ne" : @30} },
+                @{ @"age" : @{@"$eq" : @42} },
+            ];
+            CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:clause];
+            expect(parts.sqlWithPlaceholders).to.equal(@"\"age\" > ? AND \"age\" <= ? AND "
+                                                       @"\"name\" = ? AND \"age\" != ? AND "
+                                                       @"\"age\" = ?");
+            expect(parts.placeholderValues).to.equal(@[ @12, @54, @"mike", @30, @42 ]);
+        });
+    });
+
+    describe(@"when generating query SELECT clauses", ^{
+
+        it(@"returns nil for no query terms", ^{
+            CDTQSqlParts *parts =
+                [CDTQQuerySqlTranslator selectStatementForAndClause:@[] usingIndex:@"named"];
+            expect(parts).to.beNil();
+        });
+
+        it(@"returns nil for no index name", ^{
+            CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                selectStatementForAndClause:@[
+                                               @{ @"name" : @{@"$eq" : @"mike"} }
+                                            ]
+                                 usingIndex:nil];
+            expect(parts).to.beNil();
+        });
+
+        it(@"returns correctly for single query term", ^{
+            CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                selectStatementForAndClause:@[
+                                               @{ @"name" : @{@"$eq" : @"mike"} }
+                                            ]
+                                 usingIndex:@"anIndex"];
+            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_anIndex "
+                             "WHERE \"name\" = ?;";
+            expect(parts.sqlWithPlaceholders).to.equal(sql);
+            expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
+        });
+
+        it(@"returns correctly for many query terms", ^{
+            NSArray *andClause = @[
+                @{ @"name" : @{@"$eq" : @"mike"} },
+                @{ @"age" : @{@"$eq" : @12} },
+                @{ @"pet" : @{@"$eq" : @"cat"} }
+            ];
+            CDTQSqlParts *parts = [CDTQQuerySqlTranslator selectStatementForAndClause:andClause
+                                                                           usingIndex:@"anIndex"];
+            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_anIndex "
+                             "WHERE \"name\" = ? AND \"age\" = ? AND \"pet\" = ?;";
+            expect(parts.sqlWithPlaceholders).to.equal(sql);
+            expect(parts.placeholderValues).to.equal(@[ @"mike", @12, @"cat" ]);
+        });
+    });
+
+    describe(@"when normalising queries", ^{
+
+        it(@"expands top-level implicit $and single field", ^{
+            NSDictionary *actual = [CDTQQueryValidator normaliseAndValidateQuery:@{ @"name" : @"mike" }];
+            expect(actual).to.equal(@{ @"$and" : @[ @{@"name" : @{@"$eq" : @"mike"}} ] });
+        });
+
+        it(@"expands top-level implicit $and multi field", ^{
+            NSDictionary *actual = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"name" : @"mike",
+                @"pet" : @"cat",
+                @"age" : @12
+            }];
+            expect(actual).to.equal(@{
+                @"$and" : @[
+                    @{@"pet" : @{@"$eq" : @"cat"}},
+                    @{@"name" : @{@"$eq" : @"mike"}},
+                    @{@"age" : @{@"$eq" : @12}}
+                ]
+            });
+        });
+
+        it(@"doesn't change already normalised query", ^{
+            NSDictionary *actual = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"$and" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"}, @{@"age" : @12} ]
+            }];
+            expect(actual).to.equal(@{
+                @"$and" : @[
+                    @{@"name" : @{@"$eq" : @"mike"}},
+                    @{@"pet" : @{@"$eq" : @"cat"}},
+                    @{@"age" : @{@"$eq" : @12}}
+                ]
+            });
+        });
+    });
+
+    describe(@"when extracting and clause field names", ^{
+
+        it(@"extracts a no field names", ^{
+            NSArray *fields = [CDTQQuerySqlTranslator fieldsForAndClause:@[]];
+            expect(fields).to.equal(@[]);
+        });
+
+        it(@"extracts a single field name", ^{
+            NSArray *fields =
+                [CDTQQuerySqlTranslator fieldsForAndClause:@[
+                                                              @{ @"name" : @"mike" }
+                                                           ]];
+            expect(fields).to.equal(@[ @"name" ]);
+        });
+
+        it(@"extracts a multiple field names", ^{
+            NSArray *fields = [CDTQQuerySqlTranslator fieldsForAndClause:@[
+                                                                            @{ @"name" : @"mike" },
+                                                                            @{ @"pet" : @"cat" },
+                                                                            @{ @"age" : @12 }
+                                                                         ]];
+            expect(fields).to.equal(@[ @"name", @"pet", @"age" ]);
+        });
+    });
+});
 
 SpecEnd

--- a/Example/Tests/CDTQUnindexedMatcherTests.m
+++ b/Example/Tests/CDTQUnindexedMatcherTests.m
@@ -13,19 +13,18 @@
 #import <CDTQResultSet.h>
 #import <CDTQQueryExecutor.h>
 #import <CDTQUnindexedMatcher.h>
+#import <CDTQQueryValidator.h>
 
-SpecBegin(CDTQUnindexedMatcher)
+SpecBegin(CDTQUnindexedMatcher) describe(@"matcherWithSelector", ^{
 
-    describe(@"matcherWithSelector", ^{
-
-        it(@"returns initialised object", ^{
-            CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:@{
-                @"n" : @"m"
-            }];
-            expect(matcher).toNot.beNil();
-        });
-
+    it(@"returns initialised object", ^{
+        CDTQUnindexedMatcher *matcher =
+            [CDTQUnindexedMatcher matcherWithSelector:[CDTQQueryValidator normaliseAndValidateQuery:@{
+                                                          @"n" : @"m"
+                                                      }]];
+        expect(matcher).toNot.beNil();
     });
+});
 
 describe(@"matches", ^{
 
@@ -49,51 +48,59 @@ describe(@"matches", ^{
         context(@"eq", ^{
 
             it(@"matches", ^{
-                NSDictionary *selector = @{ @"name" : @{@"$eq" : @"mike"} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$eq" : @"mike"}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
 
             it(@"doesn't match", ^{
-                NSDictionary *selector = @{ @"name" : @{@"$eq" : @"fred"} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$eq" : @"fred"}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beFalsy();
             });
 
             it(@"doesn't match bad field", ^{
-                NSDictionary *selector = @{ @"species" : @{@"$eq" : @"fred"} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"species" : @{@"$eq" : @"fred"}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beFalsy();
             });
-
         });
 
         context(@"implied eq", ^{
 
             it(@"matches", ^{
-                NSDictionary *selector = @{ @"name" : @"mike" };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{ @"name" : @"mike" }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
 
             it(@"doesn't match", ^{
-                NSDictionary *selector = @{ @"name" : @"fred" };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{ @"name" : @"fred" }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beFalsy();
             });
 
             it(@"doesn't match bad field", ^{
-                NSDictionary *selector = @{ @"species" : @"fred" };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"species" : @"fred"
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beFalsy();
             });
-
         });
 
         context(@"ne", ^{
 
             it(@"matches", ^{
-                NSDictionary *selector = @{ @"name" : @{@"$ne" : @"fred"} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$ne" : @"fred"}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
@@ -105,29 +112,36 @@ describe(@"matches", ^{
             });
 
             it(@"matches bad field", ^{
-                NSDictionary *selector = @{ @"species" : @{@"$ne" : @"fred"} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"species" : @{@"$ne" : @"fred"}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
-
         });
 
         context(@"gt", ^{
 
             it(@"matches string", ^{
-                NSDictionary *selector = @{ @"name" : @{@"$gt" : @"andy"} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$gt" : @"andy"}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
 
             it(@"matches int", ^{
-                NSDictionary *selector = @{ @"age" : @{@"$gt" : @12} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"age" : @{@"$gt" : @12}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
 
             it(@"doesn't match string", ^{
-                NSDictionary *selector = @{ @"name" : @{@"$gt" : @"robert"} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$gt" : @"robert"}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beFalsy();
             });
@@ -143,116 +157,147 @@ describe(@"matches", ^{
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beFalsy();
             });
-
         });
 
         context(@"gte", ^{
 
             it(@"matches string", ^{
-                NSDictionary *selector = @{ @"name" : @{@"$gte" : @"andy"} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$gte" : @"andy"}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
 
             it(@"matches equal string", ^{
-                NSDictionary *selector = @{ @"name" : @{@"$gte" : @"mike"} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$gte" : @"mike"}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
 
             it(@"matches int", ^{
-                NSDictionary *selector = @{ @"age" : @{@"$gte" : @12} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"age" : @{@"$gte" : @12}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
 
             it(@"matches equal int", ^{
-                NSDictionary *selector = @{ @"age" : @{@"$gte" : @31} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"age" : @{@"$gte" : @31}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
 
             it(@"doesn't match string", ^{
-                NSDictionary *selector = @{ @"name" : @{@"$gte" : @"robert"} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$gte" : @"robert"}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beFalsy();
             });
 
             it(@"doesn't match int", ^{
-                NSDictionary *selector = @{ @"age" : @{@"$gte" : @45} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"age" : @{@"$gte" : @45}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beFalsy();
             });
 
             it(@"doesn't match bad field", ^{
-                NSDictionary *selector = @{ @"species" : @{@"$gte" : @"fred"} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"species" : @{@"$gte" : @"fred"}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beFalsy();
             });
-
         });
 
         context(@"lt", ^{
 
             it(@"matches string", ^{
-                NSDictionary *selector = @{ @"name" : @{@"$lt" : @"robert"} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$lt" : @"robert"}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
 
             it(@"matches int", ^{
-                NSDictionary *selector = @{ @"age" : @{@"$lt" : @45} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"age" : @{@"$lt" : @45}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
 
             it(@"doesn't match string", ^{
-                NSDictionary *selector = @{ @"name" : @{@"$lt" : @"andy"} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$lt" : @"andy"}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beFalsy();
             });
 
             it(@"doesn't match int", ^{
-                NSDictionary *selector = @{ @"age" : @{@"$lt" : @12} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"age" : @{@"$lt" : @12}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beFalsy();
             });
 
             it(@"doesn't match bad field", ^{
-                NSDictionary *selector = @{ @"species" : @{@"$lt" : @"fred"} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"species" : @{@"$lt" : @"fred"}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beFalsy();
             });
-
         });
         context(@"lte", ^{
 
             it(@"matches string", ^{
-                NSDictionary *selector = @{ @"name" : @{@"$lte" : @"robert"} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$lte" : @"robert"}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
 
             it(@"matches equal string", ^{
-                NSDictionary *selector = @{ @"name" : @{@"$lte" : @"mike"} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$lte" : @"mike"}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
 
             it(@"matches int", ^{
-                NSDictionary *selector = @{ @"age" : @{@"$lte" : @45} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"age" : @{@"$lte" : @45}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
 
             it(@"matches equal int", ^{
-                NSDictionary *selector = @{ @"age" : @{@"$lte" : @31} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"age" : @{@"$lte" : @31}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
 
             it(@"doesn't match string", ^{
-                NSDictionary *selector = @{ @"name" : @{@"$lte" : @"andy"} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$lte" : @"andy"}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beFalsy();
             });
@@ -268,37 +313,42 @@ describe(@"matches", ^{
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beFalsy();
             });
-
         });
 
         context(@"exists", ^{
 
             it(@"matches existing", ^{
-                NSDictionary *selector = @{ @"name" : @{@"$exists" : @YES} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$exists" : @YES}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
 
             it(@"doesn't match existing", ^{
-                NSDictionary *selector = @{ @"name" : @{@"$exists" : @NO} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$exists" : @NO}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beFalsy();
             });
 
             it(@"matches missing", ^{
-                NSDictionary *selector = @{ @"species" : @{@"$exists" : @NO} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"species" : @{@"$exists" : @NO}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
 
             it(@"doesn't match missing", ^{
-                NSDictionary *selector = @{ @"species" : @{@"$exists" : @YES} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"species" : @{@"$exists" : @YES}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beFalsy();
             });
-
         });
-
     });
 
     context(@"compound", ^{
@@ -306,79 +356,76 @@ describe(@"matches", ^{
         context(@"and", ^{
 
             it(@"matches all", ^{
-                NSDictionary *selector = @{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
                     @"$and" : @[ @{@"name" : @{@"$eq" : @"mike"}}, @{@"age" : @{@"$eq" : @31}} ]
-                };
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
 
             it(@"doesn't match some", ^{
-                NSDictionary *selector = @{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
                     @"$and" : @[ @{@"name" : @{@"$eq" : @"mike"}}, @{@"age" : @{@"$eq" : @12}} ]
-                };
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beFalsy();
             });
 
             it(@"doesn't match any", ^{
-                NSDictionary *selector = @{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
                     @"$and" : @[ @{@"name" : @{@"$eq" : @"fred"}}, @{@"age" : @{@"$eq" : @12}} ]
-                };
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beFalsy();
             });
-
         });
 
         context(@"implicit and", ^{
 
             it(@"matches", ^{
-                NSDictionary *selector = @{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
                     @"name" : @{@"$eq" : @"mike"},
                     @"age" : @{@"$eq" : @31}
-                };
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
 
             it(@"doesn't match", ^{
-                NSDictionary *selector = @{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
                     @"name" : @{@"$eq" : @"mike"},
                     @"age" : @{@"$eq" : @12}
-                };
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beFalsy();
             });
-
         });
 
         context(@"or", ^{
 
             it(@"matches all okay", ^{
-                NSDictionary *selector = @{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
                     @"$or" : @[ @{@"name" : @{@"$eq" : @"mike"}}, @{@"age" : @{@"$eq" : @31}} ]
-                };
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
 
             it(@"matches one okay", ^{
-                NSDictionary *selector = @{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
                     @"$or" : @[ @{@"name" : @{@"$eq" : @"mike"}}, @{@"age" : @{@"$eq" : @12}} ]
-                };
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
 
             it(@"doesn't match", ^{
-                NSDictionary *selector = @{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
                     @"$or" : @[ @{@"name" : @{@"$eq" : @"fred"}}, @{@"age" : @{@"$eq" : @12}} ]
-                };
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beFalsy();
             });
-
         });
     });
 
@@ -389,71 +436,84 @@ describe(@"matches", ^{
         context(@"eq", ^{
 
             it(@"doesn't match", ^{
-                NSDictionary *selector = @{ @"name" : @{@"$not" : @{@"$eq" : @"mike"}} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$not" : @{@"$eq" : @"mike"}}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beFalsy();
             });
 
             it(@"matches", ^{
-                NSDictionary *selector = @{ @"name" : @{@"$not" : @{@"$eq" : @"fred"}} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$not" : @{@"$eq" : @"fred"}}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
 
             it(@"matches bad field", ^{
-                NSDictionary *selector = @{ @"species" : @{@"$not" : @{@"$eq" : @"fred"}} };
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"species" : @{@"$not" : @{@"$eq" : @"fred"}}
+                }];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:rev]).to.beTruthy();
             });
-
         });
-
     });
 
     context(@"array fields", ^{
 
         it(@"matches", ^{
-            NSDictionary *selector = @{ @"pets" : @"white_cat" };
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"pets" : @"white_cat"
+            }];
             CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
             expect([matcher matches:rev]).to.beTruthy();
         });
 
         it(@"matches good item with not", ^{
-            NSDictionary *selector = @{ @"pets" : @{@"$not" : @{@"$eq" : @"white_cat"}} };
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"pets" : @{@"$not" : @{@"$eq" : @"white_cat"}}
+            }];
             CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
             expect([matcher matches:rev]).to.beTruthy();
         });
 
         it(@"doesn't match bad item", ^{
-            NSDictionary *selector = @{ @"pets" : @"tabby_cat" };
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"pets" : @"tabby_cat"
+            }];
             CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
             expect([matcher matches:rev]).to.beFalsy();
         });
 
         it(@"matches bad item with not", ^{
-            NSDictionary *selector = @{ @"pets" : @{@"$not" : @{@"$eq" : @"tabby_cat"}} };
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"pets" : @{@"$not" : @{@"$eq" : @"tabby_cat"}}
+            }];
             CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
             expect([matcher matches:rev]).to.beTruthy();
         });
-
     });
 
     context(@"dotted fields", ^{
 
         it(@"matches", ^{
-            NSDictionary *selector = @{ @"address.number" : @"1" };
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"address.number" : @"1"
+            }];
             CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
             expect([matcher matches:rev]).to.beTruthy();
         });
 
         it(@"doesn't match", ^{
-            NSDictionary *selector = @{ @"address.number" : @"2" };
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"address.number" : @"2"
+            }];
             CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
             expect([matcher matches:rev]).to.beFalsy();
         });
-
     });
-
 });
 
 SpecEnd

--- a/Pod/Classes/CDTQQueryExecutor.m
+++ b/Pod/Classes/CDTQQueryExecutor.m
@@ -21,6 +21,7 @@
 #import "CDTQUnindexedMatcher.h"
 #import "CDTDatastore.h"
 #import "CDTDocumentRevision.h"
+#import "CDTQQueryValidator.h"
 
 #import "FMDB.h"
 
@@ -68,6 +69,14 @@ const NSUInteger kSmallResultSetSizeThreshold = 500;
         return nil;  // validate logs error message
     }
 
+    // normailse and validate query by passing into the executors
+
+    query = [CDTQQueryValidator normaliseAndValidateQuery:query];
+
+    if (!query) {
+        return nil;
+    }
+
     //
     // Execute the query
     //
@@ -103,9 +112,8 @@ const NSUInteger kSmallResultSetSizeThreshold = 500;
         return nil;
     }
 
-    // Apply post-hoc filtering
-
     CDTQUnindexedMatcher *matcher = [self matcherForIndexCoverage:indexesCoverQuery selector:query];
+
     if (matcher) {
         LogWarn(@"Query could not be executed using indexes alone; falling back to filtering "
                 @"documents themselves. This will be VERY SLOW as each candidate document is "

--- a/Pod/Classes/CDTQQuerySqlTranslator.h
+++ b/Pod/Classes/CDTQQuerySqlTranslator.h
@@ -117,7 +117,7 @@
 /**
  Expand implicit operators in a query.
  */
-+ (NSDictionary *)normaliseQuery:(NSDictionary *)query;
+//+ (NSDictionary *)normaliseQuery:(NSDictionary *)query;
 
 /**
  Extract fields from an AND clause

--- a/Pod/Classes/CDTQQueryValidator.h
+++ b/Pod/Classes/CDTQQueryValidator.h
@@ -1,0 +1,20 @@
+//
+//  CDTQQueryValidator.h
+//  Pods
+//
+//  Created by Rhys Short on 06/11/2014.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+// This class contains common validation options for the
+// two different implementations of query
+@interface CDTQQueryValidator : NSObject
+
+/**
+ Expand implicit operators in a query, and validate
+ */
++ (NSDictionary *)normaliseAndValidateQuery:(NSDictionary *)query;
+
+@end

--- a/Pod/Classes/CDTQQueryValidator.m
+++ b/Pod/Classes/CDTQQueryValidator.m
@@ -1,0 +1,240 @@
+//
+//  CDTQQueryValidator.m
+//  Pods
+//
+//  Created by Rhys Short on 06/11/2014.
+//
+//
+
+#import "CDTQQueryValidator.h"
+#import "CDTQLogging.h"
+
+@implementation CDTQQueryValidator
+
+static const NSString *AND = @"$and";
+static const NSString *OR = @"$or";
+static const NSString *EQ = @"$eq";
+
++ (NSDictionary *)normaliseAndValidateQuery:(NSDictionary *)query
+{
+    bool isWildCard = [query count] == 0;
+
+    // First expand the query to include a leading compound predicate
+    // if there isn't one already.
+    query = [CDTQQueryValidator addImplicitAnd:query];
+
+    // At this point we will have a single entry dict, key AND or OR,
+    // forming the compound predicate.
+    // Next make sure all the predicates have an operator -- the EQ
+    // operator is implicit and we need to add it if there isn't one.
+    // Take
+    //     @[ @{"field1": @"mike"}, ... ]
+    // and make
+    //     @[ @{"field1": @{ @"$eq": @"mike"} }, ... } ]
+    NSString *compoundOperator = [query allKeys][0];
+    NSArray *predicates = query[compoundOperator];
+    if ([predicates isKindOfClass:[NSArray class]]) {
+        predicates = [CDTQQueryValidator addImplicitEq:predicates];
+    }
+
+    NSDictionary *selector = @{compoundOperator : predicates};
+    if (isWildCard) {
+        return selector;
+    } else if ([CDTQQueryValidator validateSelector:selector]) {
+        return selector;
+    }
+
+    return nil;
+}
+
+#pragma mark Normalization methods
++ (NSDictionary *)addImplicitAnd:(NSDictionary *)query
+{
+    // query is:
+    //  either @{ @"field1": @"value1", ... } -- we need to add $and
+    //  or     @{ @"$and": @[ ... ] } -- we don't
+    //  or     @{ @"$or": @[ ... ] } -- we don't
+
+    if (query.count == 1 && (query[AND] || query[OR])) {
+        return query;
+    } else {
+        // Take
+        //     @{"field1": @"mike", ...}
+        //     @{"field1": @[ @"mike", @"bob" ], ...}
+        // and make
+        //     @[ @{"field1": @"mike"}, ... ]
+        //     @[ @{"field1": @[ @"mike", @"bob" ]}, ... ]
+
+        NSMutableArray *andClause = [NSMutableArray array];
+        for (NSString *k in query) {
+            NSObject *predicate = query[k];
+            [andClause addObject:@{k : predicate}];
+        }
+        return @{AND : [NSArray arrayWithArray:andClause]};
+    }
+}
+
++ (NSArray *)addImplicitEq:(NSArray *)andClause
+{
+    NSMutableArray *accumulator = [NSMutableArray array];
+
+    for (NSDictionary *fieldClause in andClause) {
+        // fieldClause is:
+        //  either @{ @"field1": @"mike"} -- we need to add the $eq operator
+        //  or     @{ @"field1": @{ @"$operator": @"value" } -- we don't
+        //  or     @{ @"$and": @[ ... ] } -- we don't
+        //  or     @{ @"$or": @[ ... ] } -- we don't
+        NSObject *predicate = nil;
+        NSString *fieldName = nil;
+        // if this isn't a dictionary, we don't know what to do so pass it back
+        if ([fieldClause isKindOfClass:[NSDictionary class]] && [fieldClause count] != 0) {
+            fieldName = fieldClause.allKeys[0];
+            predicate = fieldClause[fieldName];
+        } else {
+            [accumulator addObject:fieldClause];
+            continue;
+        }
+
+        // If the clause isn't a special clause (the field name starts with
+        // $, e.g., $and), we need to check whether the clause already
+        // has an operator. If not, we need to add the implicit $eq.
+        if (![fieldName hasPrefix:@"$"]) {
+            if (![predicate isKindOfClass:[NSDictionary class]]) {
+                predicate = @{EQ : predicate};
+            }
+        } else if ([predicate isKindOfClass:[NSArray class]]) {
+            predicate = [CDTQQueryValidator addImplicitEq:(NSArray *)predicate];
+        }
+
+        [accumulator addObject:@{fieldName : predicate}];  // can't put nil in this
+    }
+
+    return [NSArray arrayWithArray:accumulator];
+}
+
+#pragma validation class methods
+
++ (BOOL)validateCompoundOperatorClauses:(NSArray *)clauses
+{
+    BOOL valid = NO;
+
+    for (id obj in clauses) {
+        valid = NO;
+        if (![obj isKindOfClass:[NSDictionary class]]) {
+            LogError(@"Operator argument must be a dictionary %@", [clauses description]);
+            break;
+        }
+        NSDictionary *clause = (NSDictionary *)obj;
+        if ([clause count] != 1) {
+            LogError(@"Operator argument clause should only have one key value pair: %@",
+                     [clauses description]);
+            break;
+        }
+
+        NSString *key = [obj allKeys][0];
+        if ([@[ @"$or", @"$not", @"$and" ] containsObject:key]) {
+            // this should have an array as top level type
+            id compundClauses = [obj objectForKey:key];
+            if ([CDTQQueryValidator validateCompoundOperatorOperand:compundClauses]) {
+                // validate array
+                valid = [CDTQQueryValidator validateCompoundOperatorClauses:compundClauses];
+            }
+        } else if (![key hasPrefix:@"$"]) {
+            // this should have a dict
+            // send this for validation
+            valid = [CDTQQueryValidator validateClause:[obj objectForKey:key]];
+        } else {
+            LogError(@"%@ operator cannot be a top level operator", key);
+            break;
+        }
+
+        if (!valid) {
+            break;  // if we have gotten here with valid being no, we should abort
+        }
+    }
+
+    return valid;
+}
+
++ (BOOL)validateClause:(NSDictionary *)clause
+{
+    //$exits lt
+
+    NSArray *validOperators =
+        @[ @"$eq", @"$lt", @"$gt", @"$exists", @"$not", @"$ne", @"$gte", @"$lte" ];
+
+    if ([clause count] == 1) {
+        NSString *operator= [clause allKeys][0];
+
+    if ([validOperators containsObject:operator]) {
+        // contains correct operator
+        id clauseOperand = [clause objectForKey:[clause allKeys][0]];
+        // handle special case, $notis the only op that expects a dict
+        if ([operator isEqualToString:@"$not"] && [clauseOperand isKindOfClass:[NSDictionary class]]) {
+            return [CDTQQueryValidator validateClause:clauseOperand];
+
+        } else if ([CDTQQueryValidator validatePredicateValue:clauseOperand
+                                                  forOperator:[clause allKeys][0]]) {
+            return YES;
+        }
+    }
+    }
+
+    return NO;
+}
+
++ (BOOL)validatePredicateValue:(NSObject *)predicateValue forOperator:(NSString *) operator
+{
+    if([operator isEqualToString:@"$exists"]){
+        return [CDTQQueryValidator validateExistsArgument:predicateValue];
+    } else {
+        return (([predicateValue isKindOfClass:[NSString class]] ||
+                 [predicateValue isKindOfClass:[NSNumber class]]));
+    }
+}
+
++ (BOOL)validateExistsArgument:(NSObject *)exists
+{
+    BOOL valid = YES;
+
+    if (![exists isKindOfClass:[NSNumber class]]) {
+        valid = NO;
+        LogError(@"$exists operator expects YES or NO");
+    }
+
+    return valid;
+}
+
++ (BOOL)validateCompoundOperatorOperand:(NSObject *)operand
+{
+    if (![operand isKindOfClass:[NSArray class]]) {
+        LogError(@"Arugment to compound operator is not an NSArray: %@", [operand description]);
+        return NO;
+    }
+    return YES;
+}
+
+// we are going to need to walk the query tree to validate it before executing it
+// this isn't going to be fun :'(
+
++ (BOOL)validateSelector:(NSDictionary *)selector
+{
+    // after normalising we should have a few top level selectors
+
+    NSString *topLevelOp = [selector allKeys][0];
+
+    // top level op can only be $and after normalisation
+
+    if ([@[ @"$and", @"$or" ] containsObject:topLevelOp]) {
+        // top level should be $and or $or they should have arrays
+        id topLevelArg = [selector objectForKey:topLevelOp];
+
+        if ([topLevelArg isKindOfClass:[NSArray class]]) {
+            // safe we know its an NSArray
+            return [CDTQQueryValidator validateCompoundOperatorClauses:topLevelArg];
+        }
+    }
+    return NO;
+}
+
+@end


### PR DESCRIPTION
- Created new class CDTQQueryValidator
- Moved Normlisation functions into CDTQQueryValidator
- Moved validation functions into CDTQQueryValidator
- Validate entire query in one step after normalisation but before
  returning normalised query

I'm not sure about calling CDTQQueryValidator CDTQQueryValidator, any ideas on a better name?

Apologies for large whitespace commits file to focus on CDTQQueryValidator.m
