### PR TITLE
42939 custom matchers

### DIFF
--- a/Example/CloudantQueryObjc.xcodeproj/project.pbxproj
+++ b/Example/CloudantQueryObjc.xcodeproj/project.pbxproj
@@ -34,6 +34,9 @@
 		6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
 		6003F5BA195388D20070C39A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6003F5B8195388D20070C39A /* InfoPlist.strings */; };
 		6003F5BC195388D20070C39A /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6003F5BB195388D20070C39A /* Tests.m */; };
+		983CD1B91A6FC13100BCF1EC /* CDTQContainsAllElementsMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 983CD1B81A6FC13100BCF1EC /* CDTQContainsAllElementsMatcher.m */; };
+		983CD1C21A70035400BCF1EC /* CDTQQueryMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 983CD1C11A70035400BCF1EC /* CDTQQueryMatcher.m */; };
+		983CD1C51A70136300BCF1EC /* CDTQEitherMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 983CD1C41A70136300BCF1EC /* CDTQEitherMatcher.m */; };
 		98816E6119F8FC71003D98B8 /* CDTQIndexManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98816E5E19F8FC71003D98B8 /* CDTQIndexManagerTests.m */; };
 		98816E6219F8FC71003D98B8 /* CDTQPerformanceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98816E5F19F8FC71003D98B8 /* CDTQPerformanceTests.m */; };
 		98816E6319F8FC71003D98B8 /* CDTQQuerySortTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98816E6019F8FC71003D98B8 /* CDTQQuerySortTests.m */; };
@@ -92,6 +95,12 @@
 		606FC2411953D9B200FFA9A0 /* Tests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Tests-Prefix.pch"; sourceTree = "<group>"; };
 		7D2FF5055D8CEB931C7BDD68 /* Pods-CloudantQueryObjc.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CloudantQueryObjc.release.xcconfig"; path = "Pods/Target Support Files/Pods-CloudantQueryObjc/Pods-CloudantQueryObjc.release.xcconfig"; sourceTree = "<group>"; };
 		8E1E056393FB8EF38FDB0032 /* CloudantQueryObjc.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = CloudantQueryObjc.podspec; path = ../CloudantQueryObjc.podspec; sourceTree = "<group>"; };
+		983CD1B81A6FC13100BCF1EC /* CDTQContainsAllElementsMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CDTQContainsAllElementsMatcher.m; path = Matchers/CDTQContainsAllElementsMatcher.m; sourceTree = "<group>"; };
+		983CD1BA1A6FC18D00BCF1EC /* CDTQContainsAllElementsMatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CDTQContainsAllElementsMatcher.h; path = Matchers/CDTQContainsAllElementsMatcher.h; sourceTree = "<group>"; };
+		983CD1C01A70035400BCF1EC /* CDTQQueryMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CDTQQueryMatcher.h; path = Matchers/CDTQQueryMatcher.h; sourceTree = "<group>"; };
+		983CD1C11A70035400BCF1EC /* CDTQQueryMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CDTQQueryMatcher.m; path = Matchers/CDTQQueryMatcher.m; sourceTree = "<group>"; };
+		983CD1C31A70136300BCF1EC /* CDTQEitherMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CDTQEitherMatcher.h; path = Matchers/CDTQEitherMatcher.h; sourceTree = "<group>"; };
+		983CD1C41A70136300BCF1EC /* CDTQEitherMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CDTQEitherMatcher.m; path = Matchers/CDTQEitherMatcher.m; sourceTree = "<group>"; };
 		98816E5E19F8FC71003D98B8 /* CDTQIndexManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQIndexManagerTests.m; sourceTree = "<group>"; };
 		98816E5F19F8FC71003D98B8 /* CDTQPerformanceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQPerformanceTests.m; sourceTree = "<group>"; };
 		98816E6019F8FC71003D98B8 /* CDTQQuerySortTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQQuerySortTests.m; sourceTree = "<group>"; };
@@ -211,6 +220,7 @@
 		6003F5B5195388D20070C39A /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				983CD1B71A6FC0B500BCF1EC /* Matchers */,
 				98E501781A1CECE70017DC5E /* CDTDatastoreQueryTests.m */,
 				273220AF1A053D350039DF69 /* Mocks */,
 				98816E5E19F8FC71003D98B8 /* CDTQIndexManagerTests.m */,
@@ -260,6 +270,19 @@
 				BCEBEBED17811A0373FCB306 /* Pods-Tests.release.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		983CD1B71A6FC0B500BCF1EC /* Matchers */ = {
+			isa = PBXGroup;
+			children = (
+				983CD1B81A6FC13100BCF1EC /* CDTQContainsAllElementsMatcher.m */,
+				983CD1BA1A6FC18D00BCF1EC /* CDTQContainsAllElementsMatcher.h */,
+				983CD1C01A70035400BCF1EC /* CDTQQueryMatcher.h */,
+				983CD1C11A70035400BCF1EC /* CDTQQueryMatcher.m */,
+				983CD1C31A70136300BCF1EC /* CDTQEitherMatcher.h */,
+				983CD1C41A70136300BCF1EC /* CDTQEitherMatcher.m */,
+			);
+			name = Matchers;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -446,7 +469,9 @@
 				2756496819DB1605007BAA32 /* CDTQIndexUpdaterTests.m in Sources */,
 				6003F5BC195388D20070C39A /* Tests.m in Sources */,
 				273220BB1A054FAE0039DF69 /* CDTQSQLOnlyIndexManager.m in Sources */,
+				983CD1C51A70136300BCF1EC /* CDTQEitherMatcher.m in Sources */,
 				98C18F0419F5055F00B350E7 /* CDTQFilterFieldsTest.m in Sources */,
+				983CD1B91A6FC13100BCF1EC /* CDTQContainsAllElementsMatcher.m in Sources */,
 				2756496519DB1596007BAA32 /* CDTQIndexCreatorTests.m in Sources */,
 				273220B21A053D590039DF69 /* CDTQMatcherIndexManager.m in Sources */,
 				2756496B19DB16C4007BAA32 /* CDTQQueryExecutorTests.m in Sources */,
@@ -454,6 +479,7 @@
 				273220B81A054F510039DF69 /* CDTQSQLOnlyQueryExecutor.m in Sources */,
 				2756497019DC2CDB007BAA32 /* CDTQValueExtractorTests.m in Sources */,
 				98ABE17719ED15FD00EBFC50 /* CDTQInvalidQuerySyntax.m in Sources */,
+				983CD1C21A70035400BCF1EC /* CDTQQueryMatcher.m in Sources */,
 				98816E6319F8FC71003D98B8 /* CDTQQuerySortTests.m in Sources */,
 				2756497219DEB6A1007BAA32 /* CDTQQuerySqlTranslatorTests.m in Sources */,
 			);

--- a/Example/Tests/CDTQQueryExecutorTests.m
+++ b/Example/Tests/CDTQQueryExecutorTests.m
@@ -15,6 +15,8 @@
 #import <CDTQIndexCreator.h>
 #import <CDTQResultSet.h>
 #import <CDTQQueryExecutor.h>
+#import "Matchers/CDTQContainsAllElementsMatcher.h"
+#import "Matchers/CDTQEitherMatcher.h"
 
 SharedExamplesBegin(QueryExecution)
 
@@ -1019,7 +1021,7 @@ SharedExamplesBegin(QueryExecution)
                 CDTQResultSet* result = [im find:query];
                 expect(result).toNot.beNil();
                 expect(result.documentIds.count).to.equal(2);
-                expect(result.documentIds).to.equal(@[ @"mike12", @"fred34" ]);
+                expect(result.documentIds).to.containAllElements(@[ @"mike12", @"fred34" ]);
             });
         });
 
@@ -1218,7 +1220,7 @@ SharedExamplesBegin(QueryExecution)
                         ]];
                     expect([results.documentIds count]).to.equal(20);
                     expect(results.documentIds)
-                        .to.equal(@[
+                        .to.containAllElements(@[
                             @"d90",
                             @"d91",
                             @"d92",

--- a/Example/Tests/CDTQQuerySqlTranslatorTests.m
+++ b/Example/Tests/CDTQQuerySqlTranslatorTests.m
@@ -16,6 +16,9 @@
 #import <CDTQQueryValidator.h>
 #import <Specta.h>
 #import <Expecta.h>
+#import "Matchers/CDTQContainsAllElementsMatcher.h"
+#import "Matchers/CDTQQueryMatcher.h"
+#import "Matchers/CDTQEitherMatcher.h"
 
 SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
 
@@ -103,8 +106,10 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
             CDTQSqlQueryNode *sqlNode = and.children[0];
             NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
                              "WHERE \"pet\" = ? AND \"name\" = ?;";
-            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
-            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat", @"mike" ]);
+            NSString *otherSql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+            "WHERE \"name\" = ? AND \"pet\" = ?;";
+            expect(sqlNode.sql.sqlWithPlaceholders).to.isEqualToEither(sql,otherSql);
+            expect(sqlNode.sql.placeholderValues).to.containsAllElements(@[ @"cat", @"mike" ]);
         });
 
         it(@"can cope with longhand single level ANDed query", ^{
@@ -846,7 +851,7 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
                 @"pet" : @"cat",
                 @"age" : @12
             }];
-            expect(actual).to.equal(@{
+            expect(actual).to.beTheSameQueryAs(@{
                 @"$and" : @[
                     @{@"pet" : @{@"$eq" : @"cat"}},
                     @{@"name" : @{@"$eq" : @"mike"}},
@@ -890,7 +895,7 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
                                                                             @{ @"pet" : @"cat" },
                                                                             @{ @"age" : @12 }
                                                                          ]];
-            expect(fields).to.equal(@[ @"name", @"pet", @"age" ]);
+            expect(fields).to.containAllElements(@[ @"name", @"pet", @"age" ]);
         });
     });
 });

--- a/Example/Tests/Matchers/CDTQContainsAllElementsMatcher.h
+++ b/Example/Tests/Matchers/CDTQContainsAllElementsMatcher.h
@@ -1,0 +1,23 @@
+//
+//  CDTQContainsAllElementsMatcher.h
+//  CloudantQueryObjc
+//
+//  Created by Rhys Short on 21/01/2015.
+//  Copyright (c) 2015 Cloudant Inc. All rights reserved.
+//
+
+#ifndef CloudantQueryObjc_CDTQContainsAllElementsMatcher_h
+#define CloudantQueryObjc_CDTQContainsAllElementsMatcher_h
+
+#import "Expecta.h"
+
+/**
+ * Determines if an Array contains all the specified array,
+ * this does not take account of the ordering of elements.
+ *
+ */
+EXPMatcherInterface(containsAllElements, (NSArray * expected));
+
+#define containAllElements containsAllElements
+
+#endif

--- a/Example/Tests/Matchers/CDTQContainsAllElementsMatcher.h
+++ b/Example/Tests/Matchers/CDTQContainsAllElementsMatcher.h
@@ -3,7 +3,7 @@
 //  CloudantQueryObjc
 //
 //  Created by Rhys Short on 21/01/2015.
-//  Copyright (c) 2015 Cloudant Inc. All rights reserved.
+//  Copyright (c) 2015 IBM Corp. All rights reserved.
 //
 
 #ifndef CloudantQueryObjc_CDTQContainsAllElementsMatcher_h

--- a/Example/Tests/Matchers/CDTQContainsAllElementsMatcher.m
+++ b/Example/Tests/Matchers/CDTQContainsAllElementsMatcher.m
@@ -1,0 +1,65 @@
+//
+//  CDTQContainsAllElementsMatcher.m
+//  CloudantQueryObjc
+//
+//  Created by Rhys Short on 21/01/2015.
+//  Copyright (c) 2015 Cloudant Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "CDTQContainsAllElementsMatcher.h"
+
+EXPMatcherImplementationBegin(containsAllElements,(NSArray * expected))
+
+BOOL actualIsNil = (actual == nil);
+BOOL expectedIsNil = (expected == nil);
+
+prerequisite(^BOOL {
+    return !(actualIsNil || expectedIsNil);
+});
+
+
+match(^BOOL {
+
+    BOOL matches = YES;
+    
+    for(id element in expected){
+        if([actual containsObject:element]){
+            continue;
+        }
+        matches = NO;
+        break;
+    }
+    
+    return matches;
+    
+});
+
+failureMessageForTo(^NSString * {
+    if (actualIsNil) {
+        return @"the actual value is nil/null";
+    } else if (expectedIsNil) {
+        return @"the expected value is nil/null";
+    } else {
+        return [NSString stringWithFormat:@"expected values: %@, got values %@ some are missing",
+                expected,
+                actual];
+    }
+    
+    
+});
+
+failureMessageForNotTo(^NSString * {
+    if (actualIsNil) {
+        return @"the actual value is nil/null";
+    } else if (expectedIsNil) {
+        return @"the expected value is nil/null";
+    } else {
+        return [NSString stringWithFormat:@"expected values: %@, got values %@ some are not missing",
+                expected,
+                actual];
+    }
+    
+});
+
+EXPMatcherImplementationEnd

--- a/Example/Tests/Matchers/CDTQContainsAllElementsMatcher.m
+++ b/Example/Tests/Matchers/CDTQContainsAllElementsMatcher.m
@@ -3,7 +3,7 @@
 //  CloudantQueryObjc
 //
 //  Created by Rhys Short on 21/01/2015.
-//  Copyright (c) 2015 Cloudant Inc. All rights reserved.
+//  Copyright (c) 2015 IBM Corp.  All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Example/Tests/Matchers/CDTQEitherMatcher.h
+++ b/Example/Tests/Matchers/CDTQEitherMatcher.h
@@ -3,7 +3,7 @@
 //  CloudantQueryObjc
 //
 //  Created by Rhys Short on 21/01/2015.
-//  Copyright (c) 2015 Michael Rhodes. All rights reserved.
+//  Copyright (c) 2015 IBM Corp. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Example/Tests/Matchers/CDTQEitherMatcher.h
+++ b/Example/Tests/Matchers/CDTQEitherMatcher.h
@@ -1,0 +1,18 @@
+//
+//  CDTQEitherMatcher.h
+//  CloudantQueryObjc
+//
+//  Created by Rhys Short on 21/01/2015.
+//  Copyright (c) 2015 Michael Rhodes. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "Expecta.h"
+
+/**
+ * Determines if the value matches either values.
+ *
+ */
+EXPMatcherInterface(isEqualToEither, (id expected,id otherExpected))
+
+#define isEither

--- a/Example/Tests/Matchers/CDTQEitherMatcher.m
+++ b/Example/Tests/Matchers/CDTQEitherMatcher.m
@@ -1,0 +1,35 @@
+//
+//  CDTQEitherMatcher.m
+//  CloudantQueryObjc
+//
+//  Created by Rhys Short on 21/01/2015.
+//  Copyright (c) 2015 Michael Rhodes. All rights reserved.
+//
+
+#import "CDTQEitherMatcher.h"
+
+EXPMatcherImplementationBegin(isEqualToEither, (id expected,id otherExpected))
+
+match(^BOOL {
+    
+    return [actual isEqual:expected] || [actual isEqual:otherExpected];
+    
+});
+
+failureMessageForTo(^NSString * {
+    return [NSString stringWithFormat:@"expected: %@ or %@, got values %@ some are missing",
+            expected,
+            otherExpected,
+            actual];
+    
+});
+
+failureMessageForNotTo(^NSString * {
+    return [NSString stringWithFormat:@"expected neither: %@ or %@, got values %@",
+            expected,
+            otherExpected,
+            actual];
+    
+});
+
+EXPMatcherImplementationEnd

--- a/Example/Tests/Matchers/CDTQEitherMatcher.m
+++ b/Example/Tests/Matchers/CDTQEitherMatcher.m
@@ -3,7 +3,7 @@
 //  CloudantQueryObjc
 //
 //  Created by Rhys Short on 21/01/2015.
-//  Copyright (c) 2015 Michael Rhodes. All rights reserved.
+//  Copyright (c) 2015 IBM Corp. All rights reserved.
 //
 
 #import "CDTQEitherMatcher.h"

--- a/Example/Tests/Matchers/CDTQQueryMatcher.h
+++ b/Example/Tests/Matchers/CDTQQueryMatcher.h
@@ -3,7 +3,7 @@
 //  CloudantQueryObjc
 //
 //  Created by Rhys Short on 21/01/2015.
-//  Copyright (c) 2015 Michael Rhodes. All rights reserved.
+//  Copyright (c) 2015 IBM Corp. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Example/Tests/Matchers/CDTQQueryMatcher.h
+++ b/Example/Tests/Matchers/CDTQQueryMatcher.h
@@ -1,0 +1,19 @@
+//
+//  CDTQQueryMatcher.h
+//  CloudantQueryObjc
+//
+//  Created by Rhys Short on 21/01/2015.
+//  Copyright (c) 2015 Michael Rhodes. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "Expecta.h"
+
+/**
+ *  Determines if two raw cloudant queries are the same
+ *
+ */
+EXPMatcherInterface(beTheSameQueryAs, (NSDictionary * expected));
+
+

--- a/Example/Tests/Matchers/CDTQQueryMatcher.m
+++ b/Example/Tests/Matchers/CDTQQueryMatcher.m
@@ -3,7 +3,7 @@
 //  CloudantQueryObjc
 //
 //  Created by Rhys Short on 21/01/2015.
-//  Copyright (c) 2015 Michael Rhodes. All rights reserved.
+//  Copyright (c) 2015 IBM Corp. All rights reserved.
 //
 
 #import "CDTQQueryMatcher.h"

--- a/Example/Tests/Matchers/CDTQQueryMatcher.m
+++ b/Example/Tests/Matchers/CDTQQueryMatcher.m
@@ -1,0 +1,81 @@
+//
+//  CDTQQueryMatcher.m
+//  CloudantQueryObjc
+//
+//  Created by Rhys Short on 21/01/2015.
+//  Copyright (c) 2015 Michael Rhodes. All rights reserved.
+//
+
+#import "CDTQQueryMatcher.h"
+
+EXPMatcherImplementationBegin(beTheSameQueryAs, (NSDictionary * expected))
+
+prerequisite(^BOOL {
+    
+    return [actual isKindOfClass:[NSDictionary class]];
+    
+});
+
+
+match(^BOOL {
+    
+    BOOL matches = YES;
+    NSDictionary * actualQuery = (NSDictionary*)actual;
+    
+    //first we check if dictionary has the same number of keys
+    if([actualQuery count] != [expected count]){
+        return NO;
+    }
+
+    for (id key in expected){
+        if([actualQuery objectForKey:key]){
+            //we have a key for that object
+            id object = [actualQuery objectForKey:key];
+            
+            if([object isKindOfClass:[NSArray class]] && [[expected objectForKey:key]isKindOfClass:[NSArray class]]){
+                
+                NSArray * expectedArray = (NSArray *)[expected objectForKey:key];
+                NSArray * actualArray = (NSArray *)[actualQuery objectForKey:key];
+                
+                if([expectedArray count] == [actualArray count]){
+                    for(id element in expectedArray){
+                        if(![actualArray containsObject:element]){
+                            matches = NO;
+                            break;
+                        }
+                    }
+                }
+                
+            } else {
+                if(![object isEqual:[expected objectForKey:key]]){
+                    matches = NO;
+                    break;
+                }
+            }
+        } else {
+            matches = NO;
+            break;
+        }
+    }
+    
+    
+    
+    return matches;
+    
+});
+
+failureMessageForTo(^NSString * {
+        return [NSString stringWithFormat:@"expected values: %@, got values %@ some are missing",
+                expected,
+                actual];
+    
+});
+
+failureMessageForNotTo(^NSString * {
+        return [NSString stringWithFormat:@"expected values: %@, got values %@",
+                expected,
+                actual];
+    
+});
+
+EXPMatcherImplementationEnd

--- a/Pod/Classes/CDTQQueryExecutor.m
+++ b/Pod/Classes/CDTQQueryExecutor.m
@@ -197,7 +197,7 @@ const NSUInteger kSmallResultSetSizeThreshold = 500;
             return NO;
         }
 
-        if ([field containsString:@"."]) {
+        if ([field rangeOfString:@"."].location != NSNotFound) {
             LogError(@"Projection field cannot use dotted notation: %@", [field description]);
             return NO;
         }


### PR DESCRIPTION
Add custom matchers to match arrays if it contains all the specified elements. These are implemented as two matchers, one for whole queries and one for just arrays. 

The query matcher only checks top-level dict values for arrays, if the value is an array, it performs a check
to see if allElements are in the array, other wise it calls isEqual instead.