### PR TITLE
Fix OR query missing index bug

### DIFF
--- a/Example/Tests/CDTQQueryExecutorTests.m
+++ b/Example/Tests/CDTQQueryExecutorTests.m
@@ -1342,6 +1342,39 @@ sharedExamplesFor(@"queries without covering indexes", ^(NSDictionary* data) {
             expect(result.documentIds.count).to.equal(2);
             expect(result.documentIds).to.beSupersetOf(@[ @"mike72", @"fred12" ]);
         });
+        
+        it(@"query using OR while missing a covering index", ^{
+            NSDictionary* query = @{ @"$or" : @[ @{ @"pet" : @{@"$eq" : @"cat"} },
+                                                 @{ @"town" : @{@"$eq" : @"bristol"} }
+                                               ]
+                                   };
+            CDTQResultSet* result = [im find:query];
+            expect(result).toNot.beNil();
+            expect(result.documentIds.count).to.equal(4);
+            expect(result.documentIds).to.beSupersetOf(@[ @"mike12",
+                                                          @"mike72",
+                                                          @"fred34",
+                                                          @"fred12" ]);
+        });
+        
+        it(@"query using OR without any covering indexes", ^{
+            expect([im deleteIndexNamed:@"pet"]).toNot.beNil();
+            NSDictionary *indexes = [im listIndexes];
+            expect(indexes.count).to.equal(1);
+            expect(indexes.allKeys).to.beSupersetOf(@[ @"basic" ]);
+            
+            NSDictionary* query = @{ @"$or" : @[ @{ @"pet" : @{@"$eq" : @"cat"} },
+                                                 @{ @"town" : @{@"$eq" : @"bristol"} }
+                                               ]
+                                   };
+            CDTQResultSet* result = [im find:query];
+            expect(result).toNot.beNil();
+            expect(result.documentIds.count).to.equal(4);
+            expect(result.documentIds).to.beSupersetOf(@[ @"mike12",
+                                                          @"mike72",
+                                                          @"fred34",
+                                                          @"fred12" ]);
+        });
 
         it(@"post-hoc matches when projecting over non-queried fields", ^{
             NSDictionary* query = @{ @"town" : @"bristol" };

--- a/Pod/Classes/CDTQQuerySqlTranslator.m
+++ b/Pod/Classes/CDTQQuerySqlTranslator.m
@@ -21,8 +21,9 @@
 
 @interface CDTQTranslatorState : NSObject
 
-@property (nonatomic) BOOL atLeastOneIndexUsed;     // if NO, need to generate a return all query
-@property (nonatomic) BOOL atLeastOneIndexMissing;  // i.e., we need to use posthoc matcher
+@property (nonatomic) BOOL atLeastOneIndexUsed;       // if NO, need to generate a return all query
+@property (nonatomic) BOOL atLeastOneIndexMissing;    // i.e., we need to use posthoc matcher
+@property (nonatomic) BOOL atLeastOneORIndexMissing;  //       we need to use posthoc matcher
 
 @end
 
@@ -78,7 +79,7 @@ static NSString *const EXISTS = @"$exists";
     // If we haven't used a single index, we need to return a query
     // which returns every document, so the posthoc matcher can
     // run over every document to manually carry out the query.
-    if (!state.atLeastOneIndexUsed) {
+    if (!state.atLeastOneIndexUsed || state.atLeastOneORIndexMissing) {
         NSSet *neededFields = [NSSet setWithObject:@"_id"];
         NSString *allDocsIndex =
             [CDTQQuerySqlTranslator chooseIndexForFields:neededFields fromIndexes:indexes];
@@ -192,6 +193,7 @@ static NSString *const EXISTS = @"$exists";
                 [CDTQQuerySqlTranslator chooseIndexForAndClause:wrappedClause fromIndexes:indexes];
             if (!chosenIndex) {
                 state.atLeastOneIndexMissing = YES;
+                state.atLeastOneORIndexMissing = YES;
 
                 LogWarn(@"No single index contains all of %@; add index for these fields to "
                         @"query efficiently.",


### PR DESCRIPTION
- Fix the sql translator to set a flag when an index is missing for any
OR clause and then act on that flag by providing a query that will in
turn, later provide a list of all document ids to the post hoc matcher
to match the query with.