### PR TITLE
Reduce memory usage during indexing process

### DIFF
--- a/Example/Tests/CDTQPerformanceTests.m
+++ b/Example/Tests/CDTQPerformanceTests.m
@@ -58,6 +58,9 @@ SpecBegin(CDTQPerformance)
             CDTDatastore *ds50k = [factory datastoreNamed:@"test50k" error:nil];
             CDTDatastore *ds100k = [factory datastoreNamed:@"test100k" error:nil];
             for (int i = 0; i < 100000; i++) {
+                
+                @autoreleasepool {
+                    
                 rev.docId = [NSString stringWithFormat:@"doc-%d", i];
                 rev.body = @{
                     @"name" : @"mike",
@@ -79,6 +82,8 @@ SpecBegin(CDTQPerformance)
                 }
 
                 [ds100k createDocumentFromRevision:rev error:nil];
+                    
+                }
             }
         });
 


### PR DESCRIPTION
This commit adds autorelease blocks to code paths which would build
up memory usage during testing. All these fixes are based on running
through the tests and watching memory usage manually.

1. While adding thousands of documents to a datastore

For this, the test creates over 100k documents and adds them to
datastore. Given the loop was in the test class, I added an autorelease
pool there, rather than in the -createDocumentFromRevision:error:
method. For most users, -createDocumentFromRevision:error: will be fine
to call because they won't be calling it in a loop like we are.

This reduced memory use at document creation time from over 500MB to
about 20MB.

2. In the index update process

Here, batches of up to 10,000 changes are indexed. Previously, the
autorelease pool didn't appear to be draining until all batches were
committed. The changes to CDTQIndexUpdater add autorelease pools around
sections of code which empirically benefited from them, at two points.
These reduced max memory usage for indexing from 170MB to around
40-50MB.

First, the pool is drained after each batch. This created the major
savings, dropping from 170MB to 50MB.

Secondly, I found a small improvement when adding one around each
document pushed into the database. A guess is that this is because there
are a lot of objects created during a PUT operation. However, I did't
yet run the app under instruments to verify this.