### PR TITLE
Fix NOT processing logic in query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CloudantQueryObjc CHANGELOG
 
+## 1.0.3 (Unreleased)
+
+- [FIX] Using MongoDB query as the "gold" standard, query support for `NOT` has been fixed to return result sets correctly (as in MongoDB query).  Previously, the result set from a query like `{ "pet": { "$not" { "$eq": "dog" } } }` would include a document like `{ "pet" : [ "cat", "dog" ], ... }` because the array contains an object that isn't `dog`.  The new behavior is that `$not` now inverts the result set, so this document will no longer be included because it has an array element that matches `dog`.
+
 ## 1.0.2 (2015-01-23)
 
 - [NOTE] Bump CocoaLumberjack to 2.0.0-rc.

--- a/Example/Tests/CDTQUnindexedMatcherTests.m
+++ b/Example/Tests/CDTQUnindexedMatcherTests.m
@@ -431,7 +431,8 @@ describe(@"matches", ^{
 
     context(@"not", ^{
 
-        // We can be fairly simple here as we know that the internal is that not just negates.
+        //  We can be fairly simple here as we know that the internal is that $not just negates
+        //  and $ne is just translated to $not..$eq
 
         context(@"eq", ^{
 
@@ -459,6 +460,45 @@ describe(@"matches", ^{
                 expect([matcher matches:rev]).to.beTruthy();
             });
         });
+        
+        context(@"ne", ^{
+            
+            it(@"doesn't match using $ne", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$ne" : @"mike"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+            it(@"doesn't match using $not..$ne", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$not" : @{@"$ne" : @"fred"}}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+            it(@"matches using $ne", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$ne" : @"fred"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+            it(@"matches using $not..$ne", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$not" : @{@"$ne" : @"mike"}}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+            it(@"matches bad field using $ne", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"species" : @{@"$ne" : @"fred"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+        });
     });
 
     context(@"array fields", ^{
@@ -471,12 +511,20 @@ describe(@"matches", ^{
             expect([matcher matches:rev]).to.beTruthy();
         });
 
-        it(@"matches good item with not", ^{
+        it(@"doesn't match good item with $not", ^{
             NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
                 @"pets" : @{@"$not" : @{@"$eq" : @"white_cat"}}
             }];
             CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
-            expect([matcher matches:rev]).to.beTruthy();
+            expect([matcher matches:rev]).to.beFalsy();
+        });
+        
+        it(@"doesn't match good item with $ne", ^{
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"pets" : @{@"$ne" : @"white_cat"}
+            }];
+            CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+            expect([matcher matches:rev]).to.beFalsy();
         });
 
         it(@"doesn't match bad item", ^{
@@ -487,9 +535,17 @@ describe(@"matches", ^{
             expect([matcher matches:rev]).to.beFalsy();
         });
 
-        it(@"matches bad item with not", ^{
+        it(@"matches bad item with $not", ^{
             NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
                 @"pets" : @{@"$not" : @{@"$eq" : @"tabby_cat"}}
+            }];
+            CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+            expect([matcher matches:rev]).to.beTruthy();
+        });
+        
+        it(@"matches bad item with $ne", ^{
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"pets" : @{@"$ne" : @"tabby_cat"}
             }];
             CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
             expect([matcher matches:rev]).to.beTruthy();

--- a/Pod/Classes/CDTQQuerySqlTranslator.h
+++ b/Pod/Classes/CDTQQuerySqlTranslator.h
@@ -149,7 +149,7 @@
 /**
  Returns the SQL WHERE clause for a query.
  */
-+ (CDTQSqlParts *)wherePartsForAndClause:(NSArray *)clause;
++ (CDTQSqlParts *)wherePartsForAndClause:(NSArray *)clause usingIndex:(NSString *)indexName;
 
 /**
  Returns the SQL statement to find document IDs matching query.

--- a/README.md
+++ b/README.md
@@ -339,14 +339,13 @@ a query such as:
 { pet: { $eq: cat } }
 ```
 
-Will return the document `mike32`. Negation may be slightly confusing:
+Will return the document `mike32`. Negation such as:
 
 ```
 { pet: { $not: { $eq: cat } } }
 ```
 
-Will also return `mike32` because there are values in the array that are not `cat`. That is,
-this operator is matching for "any values that do not equal 'cat'".
+Will not return `mike32` because negation returns the set of documents that are not in the set of documents returned by the non-negated query. In other words the negated query above will return all of the documents that are not in the set of documents returned by `{ pet: { $eq: cat } }`.
 
 #### Restrictions
 


### PR DESCRIPTION
This PR addresses a bug that was found related to NOT processing in Query. Using MongoDB query results as the "gold" standard and our baseline, changes were made to both the SQL engine and the post hoc matcher logic to fix NOT processing to essentially return results sets that contain documents that are NOT in the positive version of the query. This is keeping in line with how MongoDB query handles NOT processing.