### PR TITLE
Move $not/$ne processing to normalization stage

### DIFF
--- a/Pod/Classes/CDTQUnindexedMatcher.m
+++ b/Pod/Classes/CDTQUnindexedMatcher.m
@@ -37,8 +37,6 @@
 static NSString *const AND = @"$and";
 static NSString *const OR = @"$or";
 static NSString *const NOT = @"$not";
-static NSString *const NE = @"$ne";
-static NSString *const EQ = @"$eq";
 
 #pragma mark Creating matcher
 
@@ -83,14 +81,7 @@ static NSString *const EQ = @"$eq";
         NSDictionary *clause = (NSDictionary *)obj;
         NSString *field = clause.allKeys[0];
         if (![field hasPrefix:@"$"]) {
-            NSDictionary *converted = nil;
-            converted = [CDTQUnindexedMatcher convertNeClauseToNotEq:field
-                                                            onClause:[clause objectForKey:field]];
-            if (!converted) {
-                [basicClauses addObject:clauses[idx]];
-            } else {
-                [basicClauses addObject:converted];
-            }
+            [basicClauses addObject:clauses[idx]];
         }
     }];
 
@@ -130,27 +121,6 @@ static NSString *const EQ = @"$eq";
     }];
 
     return root;
-}
-
-+ (NSDictionary *)convertNeClauseToNotEq:(NSString *)field onClause:(NSDictionary *)clause
-{
-    // We either have { "$not" : { "$operator" : "value" } }
-    //     or         { "$operator" : "value" }
-    NSDictionary *converted = nil;
-    NSString *operator = clause.allKeys[0];
-    if ([operator isEqualToString:NE]) {
-        // Convert { "$ne" : "value" } to { "$not" : { "$eq" : "value" } }
-        converted = @{ field : @{ NOT : @{ EQ : [clause objectForKey:operator] } } };
-    } else if ([operator isEqualToString:NOT]) {
-        NSDictionary *subClause = [clause objectForKey:operator];
-        NSString *subOperator = subClause.allKeys[0];
-        if ([subOperator isEqualToString:NE]) {
-            // Convert { "$not" : { "$ne" : "value" } } to { "$eq" : "value" }
-            converted = @{ field : @{ EQ : [subClause objectForKey:subOperator] } };
-        }
-    }
-    
-    return converted;
 }
 
 #pragma mark Matching documents


### PR DESCRIPTION
Move $not and $ne processing to be part of normalization instead of
having individual sets of logic to handle $not and $ne in both the
post hoc matcher and the SQL engine.  This allows us to keep things
less complex in the matcher and the SQL engine logic and also allows us
to maintain one set of logic for $not and $ne processing instead of two.

Changes made:

- Add logic to handle multiple $not operators in a row during
normalization.  This condition was previously unhandled.
- Add logic to transform shorthand notion such as $ne into the long
form.  In the case of $ne it would be $not..$eq.  All future shorthand
processing will be handled as part of normalization.
- Remove $not and $ne query manipulation from SQL translator logic.
- Remove $not and $ne query manipulation from post hoc matcher logic.
- Add additional tests to test the handling of sequential $not and $ne
operators.
- Remove WHERE clause tests that specifically use $ne in the query
since a query will never have an $ne operator in it by the time it
reaches the WHERE clause generation logic.